### PR TITLE
Make JvmAgentJdk6 allow dynamic attach

### DIFF
--- a/agent/jvm-jdk6/pom.xml
+++ b/agent/jvm-jdk6/pom.xml
@@ -24,6 +24,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.sun</groupId>
+      <artifactId>tools</artifactId>
+      <scope>system</scope>
+    </dependency>
+
+    <dependency>
         <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
     </dependency>
@@ -62,6 +68,7 @@
             <manifestEntries>
               <Premain-Class>org.jolokia.jvmagent.jdk6.JvmAgentJdk6</Premain-Class>
               <Agent-Class>org.jolokia.jvmagent.jdk6.JvmAgentJdk6</Agent-Class>
+              <Main-Class>org.jolokia.jvmagent.jdk6.JvmAgentJdk6</Main-Class>
               <Can-Redefine-Classes>false</Can-Redefine-Classes>
               <Can-Retransform-Classes>false</Can-Retransform-Classes>
               <Can-Set-Native-Method-Prefix>false</Can-Set-Native-Method-Prefix>

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,14 @@
       </dependency>
 
       <dependency>
+        <groupId>com.sun</groupId>
+        <artifactId>tools</artifactId>
+        <version>1.6</version>
+        <scope>system</scope>
+        <systemPath>${java.home}/../lib/tools.jar</systemPath>
+      </dependency>
+
+      <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>5.12.1</version>


### PR DESCRIPTION
Hi there !

We have an environment thats very fluid, where jolokia would be advantageous. As part of this environment we require the ability to setup the Jvm Agent into already running instances.

It would appear that the existing agent does not perform any trickery or class manipulation so I don't forsee any issues allowing dynamic attach to work.

As such I have modified the _JvmAgentJdk6_ class to allow a _com.sun.attach program_ to load this agent into a running JVM.

Example code for doing this is as follows

``` java
   String vmHandle = "12345";
   VirtualMachine vm = VirtualMachine.attach(vmHandle);

   try {
     String agentUrl = (String) vm.getSystemProperties().get("jolokia.agent_url");
     if (agentUrl == null) {

         URI jarUri = JvmAgentJdk6.class
           .getProtectionDomain()
           .getCodeSource()
           .getLocation()
           .toURI();

         String agent = new File(jarUri).getAbsolutePath();
         vm.loadAgent(AGENT, "port=7788,host=localhost,agentContext=/jmx");
         System.out.println("Attached JMX Rest bridge to " + vmHandle);
     } else {
         System.out.println("Attach already exists " + agentUrl);
     }
   } finally {
     vm.detach();
   }
```

It would be great if you could look at these changes

thanks 

-- Greg
