### PR TITLE
invalidHost() test does not work with dyn dns configured

### DIFF
--- a/agent/jvm/src/test/java/org/jolokia/jvmagent/ServerConfigTest.java
+++ b/agent/jvm/src/test/java/org/jolokia/jvmagent/ServerConfigTest.java
@@ -104,7 +104,7 @@ public class ServerConfigTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void invalidHost() {
-        new ServerConfig("host=1923.12.5.1");
+        new ServerConfig("host=[192.168.5.0]");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
Fixed broken ServerConfigTest.invalidHost() test. 1923.12.5.1 is not a valid IP adress and is resolved as a host which does not fail when dyn dns is used. Made it an invalid ip6 adress instead.
