### PR TITLE
InstanceAlreadyExistsException keeps popping up even with UUID code

### DIFF
--- a/agent/core/src/main/java/org/jolokia/backend/LocalRequestDispatcher.java
+++ b/agent/core/src/main/java/org/jolokia/backend/LocalRequestDispatcher.java
@@ -117,7 +117,12 @@ public class LocalRequestDispatcher implements RequestDispatcher {
             String alternativeOName = oName + ",uuid=" + UUID.randomUUID();
             log.info(oName + " is already registered. Adding it with " + alternativeOName + ", but you should revise your setup in " +
                      "order to either use a qualifier or ensure, that only a single agent gets registered (otherwise history functionality might not work)");
-            mBeanServerHandler.registerMBean(config,alternativeOName);
+ 	   		try {
+          		mBeanServerHandler.registerMBean(config,alternativeOName);
+	   		} catch (InstanceAlreadyExistsException iae) {
+	   	 		// still could not register
+		 		log.info("Failed to register config mbean with alternative name: " + alternativeOName);
+	   		}
         }
 
         // Register another Config MBean (which dispatched to the stores anyway) for access by


### PR DESCRIPTION
The UUID code does not seem to help when you already have an instance of the Config MBean running (my application runs on a container that also uses Jolokia). Therefore I keep getting the nasty InstanceAlreadyExistsException. 

I added an extra try/catch block with a log message and was wondering if you could accept it for the main branch. 

Cheers,
Martin
