### PR TITLE
Fix a bug HistoryEntry.trim when the list of values is empty and max duration is > 0

### DIFF
--- a/agent/core/src/main/java/org/jolokia/history/HistoryEntry.java
+++ b/agent/core/src/main/java/org/jolokia/history/HistoryEntry.java
@@ -107,7 +107,7 @@ class HistoryEntry implements Serializable {
         }
 
         // Trim according to duration
-        if (limit.getMaxDuration() > 0) {
+        if (limit.getMaxDuration() > 0 && !values.isEmpty()) {
             long duration = limit.getMaxDuration();
             long start = values.getFirst().getTimestamp();
             while (start - values.getLast().getTimestamp() > duration) {

--- a/agent/core/src/main/java/org/jolokia/history/HistoryLimit.java
+++ b/agent/core/src/main/java/org/jolokia/history/HistoryLimit.java
@@ -28,6 +28,12 @@ public class HistoryLimit implements Serializable {
         if (pMaxEntries == 0 && pMaxDuration == 0) {
             throw new IllegalArgumentException("Invalid limit, either maxEntries or maxDuration must be != 0");
         }
+        if (pMaxEntries < 0) {
+            throw new IllegalArgumentException("Invalid limit, maxEntries must be >= 0");
+        }
+        if (pMaxDuration < 0) {
+            throw new IllegalArgumentException("Invalid limit, maxDuration must be >= 0");
+        }
         maxEntries = pMaxEntries;
         maxDuration = pMaxDuration;
     }

--- a/agent/core/src/test/java/org/jolokia/history/HistoryStoreTest.java
+++ b/agent/core/src/test/java/org/jolokia/history/HistoryStoreTest.java
@@ -93,6 +93,17 @@ public class HistoryStoreTest {
         store.configure(new HistoryKey(req), null);
         assertEquals("History disabled",null,updateNTimesAsList(req,12));
     }
+
+    @Test
+    public void reconfigure() throws MalformedObjectNameException {
+        JmxExecRequest req =
+                new JmxRequestBuilder(EXEC,"test:type=exec")
+                        .operation("op")
+                        .build();
+
+        store.configure(new HistoryKey(req), new HistoryLimit(2, 100L));
+        store.configure(new HistoryKey(req), new HistoryLimit(2, 100L));
+    }
     
     @Test
     public void durationBasedEvicting() throws MalformedObjectNameException {
@@ -283,8 +294,18 @@ public class HistoryStoreTest {
 
 
     @Test(expectedExceptions = IllegalArgumentException.class,expectedExceptionsMessageRegExp = ".*maxEntries.*maxDuration.*")
-    public void invalidHistoryLimit() {
+     public void invalidHistoryLimit() {
         new HistoryLimit(0,0L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,expectedExceptionsMessageRegExp = ".*maxEntries.*")
+    public void invalidMaxEntriesHistoryLimit() {
+        new HistoryLimit(-1,0L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,expectedExceptionsMessageRegExp = ".*maxDuration.*")
+    public void invalidMaxDurationHistoryLimit() {
+        new HistoryLimit(0,-1L);
     }
 
     @Test


### PR DESCRIPTION
This was throwing an exception when trying to access the first element of an empty list.  Includes a test case to verify the fix.  Also adds additional argument checking to the HistoryLimit constructor to prevent similar defects.
