### PR TITLE
Allow JolokiaServer to select its port dynamically

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaEmbeddedServerConfig.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaEmbeddedServerConfig.java
@@ -1,0 +1,33 @@
+package org.jolokia.jvmagent;
+
+import org.jolokia.jvmagent.JolokiaServerConfig;
+
+import java.util.Map;
+
+/*
+ * Copyright 2013 Benson Margulies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Bean-pattern config class to make it easier to start the server from code.
+ */
+public class JolokiaEmbeddedServerConfig
+    extends JolokiaServerConfig
+{
+    public JolokiaEmbeddedServerConfig(Map<String, String> pConfig) {
+        init(pConfig);
+    }
+}

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServer.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServer.java
@@ -154,6 +154,10 @@ public class JolokiaServer {
         addAuthenticatorIfNeeded(config.getUser(),config.getPassword(),context);
         initializeExecutor();
 
+        if (port == 0) {
+            port = httpServer.getAddress().getPort();
+        }
+
         url = String.format("%s://%s:%d%s",protocol,address.getCanonicalHostName(),port,contextPath);
     }
 
@@ -218,6 +222,14 @@ public class JolokiaServer {
         } catch (IOException e) {
             throw new IllegalStateException("Cannot open keystore for https communication: " + e,e);
         }
+    }
+
+    /**
+     * @return the address that the server is listening on. Thus, a program can initialize the server
+     * with 'port 0' and then retrieve the actual running port that was bound.
+     */
+    public InetSocketAddress getAddress() {
+        return httpServer.getAddress();
     }
 
     // ======================================================================================

--- a/agent/jvm/src/test/java/org/jolokia/jvmagent/JolokiaServerTest.java
+++ b/agent/jvm/src/test/java/org/jolokia/jvmagent/JolokiaServerTest.java
@@ -53,6 +53,11 @@ public class JolokiaServerTest {
 
     }
 
+    @Test
+    public void serverPicksThePort() throws IOException, InterruptedException {
+        roundtrip("host=localhost,port=0",true);
+    }
+
 
     @Test
     public void ssl() throws IOException {
@@ -86,9 +91,14 @@ public class JolokiaServerTest {
     }
 
     private void roundtrip(String pConfig, boolean pDoRequest) throws IOException {
-        int port = EnvTestUtil.getFreePort();
         String c = pConfig != null ? pConfig + "," : "";
-        JvmAgentConfig config = new JvmAgentConfig(c + "host=localhost,port=" + port);
+        boolean portSpecified = c.contains("port=");
+        c = c + "host=localhost,";
+        if (!portSpecified) {
+            int port = EnvTestUtil.getFreePort();
+            c = c + "port=" + port;
+        }
+        JvmAgentConfig config = new JvmAgentConfig(c);
         JolokiaServer server = new JolokiaServer(config,false);
         server.start();
         //Thread.sleep(2000);


### PR DESCRIPTION
With this patch, the server can be initialized with port=0. The HttpServer will pick a port, the JolokiaServer will retrieve the selected port, and store it in the URL. 

The patch also exposes the HttpServer 'getAddress()' method and an config class to which the user can supply a map instead of a string to parse.
