### PR TITLE
Added Authorization header for the ajax request

### DIFF
--- a/client/javascript/src/main/javascript/jolokia.js
+++ b/client/javascript/src/main/javascript/jolokia.js
@@ -177,6 +177,13 @@
                     }
                 });
 
+                if (ajaxParams['username'] !== 'undefined' && ajaxParams['password'] !== 'undefined') {
+                    ajaxParams.beforeSend = function (xhr) { 
+                        var tok = ajaxParams['username'] + ':' + ajaxParams['password'];
+                        xhr.setRequestHeader('Authorization', "Basic " + btoa(tok));
+                    };
+                }
+
                 if (extractMethod(request, opts) === "post") {
                     $.extend(ajaxParams, POST_AJAX_PARAMS);
                     ajaxParams.data = JSON.stringify(request);


### PR DESCRIPTION
The current authentication for ajax request relies on talking to the jolokia backend directly. When Jolokia runs behind a reverse-proxy which requires the `Authorization` header for authentication, the request fails.

This PR adds the `Authorization` header to the ajax request if `username` and `password` options are set.
