### PR TITLE
Fix race condition during shutdown causing a NPE.

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/CleanupThread.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/CleanupThread.java
@@ -99,6 +99,7 @@ class CleanupThread extends Thread {
         for (int i=0;i< pThreads.length;i++) {
             final Thread t = pThreads[i];
             if (t.isDaemon() ||
+                    t.getThreadGroup() == null || // has died on us
                     t.getThreadGroup().equals(threadGroup) ||
                     t.getName().startsWith("WrapperListener_stop_runner") || // Tanuki Java Service Wrapper (#116)
                     t.getName().startsWith("DestroyJavaVM")) {


### PR DESCRIPTION
From the getThreadGroup() Javadoc:
-   Returns the thread group to which this thread belongs.
-   This method _returns null_ if this thread has died (been stopped).

You missed this one…
