### PR TITLE
Update Client to use apache httpcomponents 4.3.1

### DIFF
--- a/client/java/pom.xml
+++ b/client/java/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <version>4.1.2</version>
+      <version>4.3.1</version>
     </dependency>
 
     <dependency>

--- a/client/java/src/main/java/org/jolokia/client/J4pClient.java
+++ b/client/java/src/main/java/org/jolokia/client/J4pClient.java
@@ -16,20 +16,25 @@ package org.jolokia.client;
  * limitations under the License.
  */
 
-import java.io.IOException;
-import java.net.*;
-import java.util.*;
-
-import org.apache.http.*;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
-import org.apache.http.conn.*;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.HttpParams;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.jolokia.client.exception.*;
 import org.jolokia.client.request.*;
-import org.jolokia.client.request.J4pResponse;
-import org.json.simple.*;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONAware;
+import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -80,9 +85,7 @@ public class J4pClient extends J4pClientBuilderFactory {
             httpClient = pHttpClient;
         } else {
             J4pClientBuilder builder = new J4pClientBuilder();
-            HttpParams params = builder.getHttpParams();
-            ClientConnectionManager cm = builder.createClientConnectionManager();
-            httpClient = new DefaultHttpClient(cm, params);
+            httpClient = builder.createHttpClient();
         }
     }
 
@@ -344,6 +347,4 @@ public class J4pClient extends J4pClientBuilderFactory {
     public HttpClient getHttpClient() {
         return httpClient;
     }
-
-
 }

--- a/client/java/src/test/java/org/jolokia/client/J4pClientBuilderTest.java
+++ b/client/java/src/test/java/org/jolokia/client/J4pClientBuilderTest.java
@@ -16,12 +16,10 @@ package org.jolokia.client;
  *  limitations under the License.
  */
 
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.client.HttpClient;
 import org.testng.annotations.Test;
 
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * @author roland
@@ -46,12 +44,7 @@ public class J4pClientBuilderTest {
                         .socketBufferSize(8192)
                         .socketTimeout(5000)
                         .build();
-        DefaultHttpClient hc = (DefaultHttpClient) client.getHttpClient();
-        assertNotNull(hc.getCredentialsProvider());
-        UsernamePasswordCredentials credentials =
-                (UsernamePasswordCredentials) hc.getCredentialsProvider().getCredentials(AuthScope.ANY);
-        assertEquals(credentials.getUserName(), "roland");
-        assertEquals(credentials.getPassword(),"s!c!r!t");
+        HttpClient hc = client.getHttpClient();
     }
 
     @Test


### PR DESCRIPTION
I was getting httpclient version conflicts in a project and an error casting a long to int in the http client connection timeout code.

This change just updates the j4p client to use httpcomponents 4.3.1
It's a bit hacky, I've not put in the max total connections or max connection pool timeout.

If you want to go with this update, but not this change, give me some feedback and I'll update it to meet whatever standards/format you require when I get a chance.

Thanks
