### PR TITLE
Correcting minor typos in the Reference documentation.

### DIFF
--- a/src/docbkx/architecture.xml
+++ b/src/docbkx/architecture.xml
@@ -88,7 +88,7 @@
     </para>
     <para>
       Jolokia can be also integrated
-      into one's own applications very easily. The <literal>joloki-core</literal>
+      into one's own applications very easily. The <literal>jolokia-core</literal>
       library (which comes bundled as a jar), includes a servlet
       which can be easily added to a custom application. <xref
       linkend="agent-war-programmatic"/> contains more information

--- a/src/docbkx/protocol/read.xml
+++ b/src/docbkx/protocol/read.xml
@@ -179,7 +179,7 @@ value: {
       <tr>
         <td><constant>attribute</constant></td>
         <td>Attribute name to read or a JSON array containing a list
-        attributes to read. No attribute is given, then all attributes
+        of attributes to read. No attribute is given, then all attributes
         are read.</td>
         <td><literal>HeapMemoryUsage</literal>, <literal>[
         "HeapMemoryUsage", "NonHeapMemoryUsage" ]</literal></td>


### PR DESCRIPTION
1. In "src/docbkx/architecture.xml", name of the library "jolokia-core" was captured as "joloki-core". Corrected that. 
2. Added a missing "to" in "src/docbkx/protocol/read.xml". 

Since, I am trying to fix some documentation, I have not signed off. Hopefully that's OK.