### PR TITLE
Fixed #204 : Introducing checkHttpMethod(request) in the JsonRequestHandler.handleRequest(MBeanServerExecutor pServerManager, R request)

### DIFF
--- a/agent/core/src/main/java/org/jolokia/handler/JsonRequestHandler.java
+++ b/agent/core/src/main/java/org/jolokia/handler/JsonRequestHandler.java
@@ -157,6 +157,7 @@ public abstract class JsonRequestHandler<R extends JmxRequest> {
     public Object handleRequest(MBeanServerExecutor pServerManager, R request)
             throws ReflectionException, InstanceNotFoundException, MBeanException, AttributeNotFoundException, IOException, NotChangedException {
         checkForRestriction(request);
+        checkHttpMethod(request);
         return doHandleRequest(pServerManager,request);
     }
 

--- a/src/docbkx/security.xml
+++ b/src/docbkx/security.xml
@@ -312,7 +312,7 @@
           But how do the agents lookup the policy file ? By default,
           the agents will lookup for a policy file top-level in the
           classpath under the name
-          <filename>jolokia-access.html</filename>. Hence for the war
+          <filename>jolokia-access.xml</filename>. Hence for the war
           agent, the policy file must be packaged within the war at
           <filename>WEB-INF/classes/jolokia-access.xml</filename>, for
           all other agents at


### PR DESCRIPTION
Introducing checkHttpMethod(request) in JsonRequestHandler.handleRequest(MBeanServerExecutor pServerManager, R request). Without this validation, the HTTP methods which are restricted in jolokia-access.xml was also being allowed.

Signed-off-by: Arnab Biswas <arnabbiswas1@outlook.com>