### PR TITLE
Fixed #150 : HistoryKey should empty pathes as null

### DIFF
--- a/agent/core/src/main/java/org/jolokia/history/HistoryKey.java
+++ b/agent/core/src/main/java/org/jolokia/history/HistoryKey.java
@@ -144,7 +144,7 @@ public class HistoryKey implements Serializable {
         type = "attribute";
         mBean = new ObjectName(pMBean);
         secondary = pAttribute;
-        path = pPath;
+        path = sanitize(pPath);
         target = pTarget;
     }
 

--- a/agent/core/src/main/java/org/jolokia/http/AgentServlet.java
+++ b/agent/core/src/main/java/org/jolokia/http/AgentServlet.java
@@ -328,15 +328,19 @@ public class AgentServlet extends HttpServlet {
         // Lookup the Agent URL if needed
         AgentDetails details = backendManager.getAgentDetails();
         if (details.isInitRequired()) {
-            if (details.isUrlMissing()) {
-                String url = getBaseUrl(NetworkUtil.sanitizeLocalUrl(pReq.getRequestURL().toString()),
-                                        extractServletPath(pReq));
-                details.setUrl(url);
+            synchronized (details) {
+                if (details.isInitRequired()) {
+                    if (details.isUrlMissing()) {
+                        String url = getBaseUrl(NetworkUtil.sanitizeLocalUrl(pReq.getRequestURL().toString()),
+                                extractServletPath(pReq));
+                        details.setUrl(url);
+                    }
+                    if (details.isSecuredMissing()) {
+                        details.setSecured(pReq.getAuthType() != null);
+                    }
+                    details.seal();
+                }
             }
-            if (details.isSecuredMissing()) {
-                details.setSecured(pReq.getAuthType() != null);
-            }
-            details.seal();
         }
     }
 


### PR DESCRIPTION
If the HistoryKey constructor receives an empty path as value, it will
consider that as null. That way both empty path and null path will have
identical handling.

Signed-off-by: Arnab Biswas <arnabbiswas1@outlook.com>