### PR TITLE
Implement streaming json responses

### DIFF
--- a/agent/core/src/main/java/org/jolokia/config/ConfigKey.java
+++ b/agent/core/src/main/java/org/jolokia/config/ConfigKey.java
@@ -137,6 +137,12 @@ public enum ConfigKey {
      */
     CANONICAL_NAMING("canonicalNaming", true, true, "true"),
 
+
+    /**
+     * Whether to use streaming json responses. Default is "false"
+     */
+    STREAMING("streaming", true, false, "false"),
+
     /**
      * Optional domain name for registering own MBeans
      */

--- a/agent/core/src/main/java/org/jolokia/util/ChunkedWriter.java
+++ b/agent/core/src/main/java/org/jolokia/util/ChunkedWriter.java
@@ -9,6 +9,13 @@ import java.nio.charset.*;
 
 /**
  * Created by gnufied on 2/7/16.
+ * Implement chunked writing of data. Part of chunking is actually already
+ * done by OutputStream and doing so here again will result in double chunking.
+ * We just ensure that, we are flushing and closing the stream properly.
+ *
+ * This code is very closely yanked from java.nio.StreamEncoder class.
+ * The reason we couldn't simply extend StreamEncoder class is, that class marks certain
+ * attributes private which are very important for overriding close and flush methods.
  */
 public class ChunkedWriter extends Writer {
 
@@ -45,7 +52,7 @@ public class ChunkedWriter extends Writer {
             throw new IOException("Stream closed");
     }
 
-    private boolean isOpen() { return isOpen; }
+    public boolean isOpen() { return isOpen; }
 
     @Override
     public void write(char[] cbuf, int off, int len) throws IOException {

--- a/agent/core/src/main/java/org/jolokia/util/ChunkedWriter.java
+++ b/agent/core/src/main/java/org/jolokia/util/ChunkedWriter.java
@@ -1,0 +1,210 @@
+package org.jolokia.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.*;
+
+/**
+ * Created by gnufied on 2/7/16.
+ */
+public class ChunkedWriter extends Writer {
+
+    private OutputStream out;
+    private Charset cs;
+    private CharsetEncoder encoder;
+    private ByteBuffer bb;
+    // Leftover first char in a surrogate pair
+    private boolean haveLeftoverChar = false;
+    private char leftoverChar;
+    private CharBuffer lcb = null;
+
+    private static final byte[] EMPTY = {};
+
+    public ChunkedWriter(OutputStream stream, String charset) {
+        super(stream);
+        this.out = stream;
+        if (Charset.isSupported(charset)) {
+            this.cs = Charset.forName(charset);
+            this.encoder = cs.newEncoder().onMalformedInput(CodingErrorAction.REPLACE)
+                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
+        } else {
+            throw new UnsupportedCharsetException(charset);
+        }
+        bb = ByteBuffer.allocate(DEFAULT_BYTE_BUFFER_SIZE);
+    }
+
+    private static final int DEFAULT_BYTE_BUFFER_SIZE = 4096;
+
+    private volatile boolean isOpen = true;
+
+    private void ensureOpen() throws IOException {
+        if (!isOpen)
+            throw new IOException("Stream closed");
+    }
+
+    private boolean isOpen() { return isOpen; }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        synchronized (lock) {
+            ensureOpen();
+            if ((off < 0) || (off > cbuf.length) || (len < 0) ||
+                    ((off + len) > cbuf.length) || ((off + len) < 0)) {
+                throw new IndexOutOfBoundsException();
+            } else if (len == 0) {
+                return;
+            }
+            implWrite(cbuf, off, len);
+        }
+    }
+
+    public void write(int c) throws IOException {
+        char cbuf[] = new char[1];
+        cbuf[0] = (char) c;
+        write(cbuf, 0, 1);
+    }
+
+    public void write(String str, int off, int len) throws IOException {
+        /* Check the len before creating a char buffer */
+        if (len < 0)
+            throw new IndexOutOfBoundsException();
+        char cbuf[] = new char[len];
+        str.getChars(off, off + len, cbuf, 0);
+        write(cbuf, 0, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        synchronized (lock) {
+            ensureOpen();
+            implFlush();
+        }
+    }
+
+    void implFlushBuffer() throws IOException {
+        if (bb.position() > 0)
+            writeBytes();
+        flushLeftOverChar(null, true);
+        try {
+            for (;;) {
+                CoderResult cr = encoder.flush(bb);
+                if (cr.isUnderflow())
+                    break;
+                if (cr.isOverflow()) {
+                    assert bb.position() > 0;
+                    writeBytes();
+                    continue;
+                }
+                cr.throwException();
+            }
+
+            if (bb.position() > 0)
+                writeBytes();
+        } catch (IOException x) {
+            encoder.reset();
+            throw x;
+        }
+        out.write(EMPTY);
+    }
+
+    void implFlush() throws IOException {
+        implFlushBuffer();
+        if (out != null)
+            out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (lock) {
+            if (!isOpen)
+                return;
+            out.close();
+            isOpen = false;
+        }
+    }
+
+    void implWrite(char cbuf[], int off, int len) throws IOException{
+        CharBuffer cb = CharBuffer.wrap(cbuf,off, len);
+
+        if(haveLeftoverChar)
+            flushLeftOverChar(cb, false);
+
+        while (cb.hasRemaining()) {
+            CoderResult cr = encoder.encode(cb, bb, false);
+
+            if (cr.isUnderflow()) {
+                assert (cb.remaining() <= 1) : cb.remaining();
+
+                if(cb.remaining() == 1) {
+                    haveLeftoverChar = true;
+                    leftoverChar = cb.get();
+                }
+                break;
+            }
+
+            if (cr.isOverflow()) {
+                assert bb.position() > 0;
+                writeBytes();
+                continue;
+            }
+            cr.throwException();
+        }
+
+    }
+
+    private void flushLeftOverChar(CharBuffer cb, boolean endOfInput) throws IOException{
+        if (!haveLeftoverChar && !endOfInput)
+            return;
+
+        if (lcb == null)
+            lcb = CharBuffer.allocate(2);
+        else
+            lcb.clear();
+
+        if (haveLeftoverChar)
+            lcb.put(leftoverChar);
+
+        if ((cb != null) && cb.hasRemaining())
+            lcb.put(cb.get());
+        lcb.flip();
+
+        while (lcb.hasRemaining() || endOfInput) {
+            CoderResult cr = encoder.encode(lcb, bb, endOfInput);
+
+            if(cr.isUnderflow()) {
+                if (lcb.hasRemaining()) {
+                    leftoverChar = lcb.get();
+                    if (cb != null && cb.hasRemaining())
+                        flushLeftOverChar(cb,endOfInput);
+                    return;
+                }
+                break;
+            }
+
+            if(cr.isOverflow()) {
+                assert bb.position() > 0;
+                writeBytes();
+                continue;
+            }
+            cr.throwException();
+        }
+        haveLeftoverChar = false;
+    }
+
+    private void writeBytes() throws IOException{
+        bb.flip();
+        int lim = bb.limit();
+        int pos = bb.position();
+        assert (pos <= lim);
+
+        int rem = (pos <= lim ? lim - pos : 0);
+
+        if (rem > 0) {
+            out.write(bb.array(), bb.arrayOffset() + pos, rem);
+        }
+        bb.clear();
+    }
+}

--- a/agent/core/src/test/java/org/jolokia/util/ChunkedWriterTest.java
+++ b/agent/core/src/test/java/org/jolokia/util/ChunkedWriterTest.java
@@ -1,0 +1,56 @@
+package org.jolokia.util;
+
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.testng.Assert.*;
+
+/**
+ * Created by gnufied on 2/8/16.
+ */
+public class ChunkedWriterTest {
+    @Test
+    public void checkFlush() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ChunkedWriter writer = new ChunkedWriter(out, "UTF-8");
+        writer.write("hello");
+        writer.flush();
+        assertEquals(out.size(), 5);
+    }
+
+    @Test
+    public void checkSmallWrite() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ChunkedWriter writer = new ChunkedWriter(out, "UTF-8");
+        writer.write("hello");
+        assertEquals(out.size(), 0);
+    }
+
+    @Test
+    public void checkBigWrite() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        String space10 = new String(new char[4100]).replace('\0', ' ');
+
+        ChunkedWriter writer = new ChunkedWriter(out, "UTF-8");
+        writer.write(space10);
+        assertEquals(out.size(), 4096);
+        writer.flush();
+        assertEquals(out.size(), 4100);
+    }
+
+    @Test
+    public void checkClose() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ChunkedWriter writer = new ChunkedWriter(out, "UTF-8");
+        assertTrue(writer.isOpen());
+        writer.close();
+
+        assertFalse(writer.isOpen());
+    }
+}

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java
@@ -112,6 +112,7 @@ public class HelpCommand extends AbstractBaseCommand {
 "    --policyLocation <url>          Location of a Jolokia policy file\n" +
 "    --mbeanQualifier <qualifier>    Qualifier to use when registering Jolokia internal MBeans\n" +
 "    --canonicalNaming <t|f>         whether to use canonicalName for ObjectNames in 'list' or 'search' (default: true)\n" +
+"    --streaming <t|f>               whether to use streaming json (default: false)\n" +
 "    --includeStackTrace <t|f>       whether to include StackTraces for error messages (default: true)\n" +
 "    --serializeException <t|f>      whether to add a serialized version of the exception in the Jolokia response (default: false)\n" +
 "    --config <configfile>           Path to a property file from where to read the configuration\n" +

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/handler/JolokiaHttpHandler.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/handler/JolokiaHttpHandler.java
@@ -32,7 +32,6 @@ import javax.management.RuntimeMBeanException;
 import javax.security.auth.Subject;
 
 import com.sun.net.httpserver.*;
-import com.sun.org.apache.xml.internal.serializer.OutputPropertiesFactory;
 import org.jolokia.backend.BackendManager;
 import org.jolokia.config.ConfigKey;
 import org.jolokia.config.Configuration;
@@ -44,7 +43,6 @@ import org.jolokia.restrictor.*;
 import org.jolokia.util.*;
 import org.json.simple.JSONAware;
 import org.json.simple.JSONStreamAware;
-import sun.net.www.http.ChunkedOutputStream;
 
 /**
  * HttpHandler for handling a Jolokia request

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/handler/JolokiaHttpHandler.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/handler/JolokiaHttpHandler.java
@@ -32,6 +32,7 @@ import javax.management.RuntimeMBeanException;
 import javax.security.auth.Subject;
 
 import com.sun.net.httpserver.*;
+import com.sun.org.apache.xml.internal.serializer.OutputPropertiesFactory;
 import org.jolokia.backend.BackendManager;
 import org.jolokia.config.ConfigKey;
 import org.jolokia.config.Configuration;
@@ -42,6 +43,8 @@ import org.jolokia.jvmagent.ParsedUri;
 import org.jolokia.restrictor.*;
 import org.jolokia.util.*;
 import org.json.simple.JSONAware;
+import org.json.simple.JSONStreamAware;
+import sun.net.www.http.ChunkedOutputStream;
 
 /**
  * HttpHandler for handling a Jolokia request
@@ -317,6 +320,47 @@ public class JolokiaHttpHandler implements HttpHandler {
     }
 
     private void sendResponse(HttpExchange pExchange, ParsedUri pParsedUri, JSONAware pJson) throws IOException {
+        boolean streaming = configuration.getAsBoolean(ConfigKey.STREAMING);
+        if (streaming) {
+            JSONStreamAware jsonStream = (JSONStreamAware)pJson;
+            sendStreamingResponse(pExchange, pParsedUri, jsonStream);
+        } else {
+            sendAllJSON(pExchange, pParsedUri, pJson);
+        }
+    }
+
+    private void sendStreamingResponse(HttpExchange pExchange, ParsedUri pParsedUri, JSONStreamAware pJson) throws IOException {
+        ChunkedWriter writer = null;
+        try {
+            Headers headers = pExchange.getResponseHeaders();
+            if (pJson != null) {
+                headers.set("Content-Type", getMimeType(pParsedUri) + "; charset=utf-8");
+                String callback = pParsedUri.getParameter(ConfigKey.CALLBACK.getKeyValue());
+                pExchange.sendResponseHeaders(200, 0);
+                writer = new ChunkedWriter(pExchange.getResponseBody(), "UTF-8");
+                if (callback == null) {
+                    pJson.writeJSONString(writer);
+                } else {
+                    writer.write("(");
+                    writer.write(callback);
+                    pJson.writeJSONString(writer);
+                    writer.write(");");
+                }
+            } else {
+                headers.set("Content-Type", "text/plain");
+                pExchange.sendResponseHeaders(200,-1);
+            }
+        } finally {
+            if (writer != null) {
+                // Always close in order to finish the request.
+                // Otherwise the thread blocks.
+                writer.flush();
+                writer.close();
+            }
+        }
+    }
+
+    private void sendAllJSON(HttpExchange pExchange, ParsedUri pParsedUri, JSONAware pJson) throws IOException {
         OutputStream out = null;
         try {
             Headers headers = pExchange.getResponseHeaders();

--- a/agent/jvm/src/main/resources/default-jolokia-agent.properties
+++ b/agent/jvm/src/main/resources/default-jolokia-agent.properties
@@ -73,6 +73,9 @@ maxObjects=0
 # Whether multicast discovery is enabled or not.
 discoveryEnabled=true
 
+# whether to stream
+streaming=false
+
 # HTTPS related setting
 secureSocketProtocol=TLS
 keyStoreType=JKS

--- a/agent/jvm/src/test/java/org/jolokia/jvmagent/handler/JolokiaHttpHandlerTest.java
+++ b/agent/jvm/src/test/java/org/jolokia/jvmagent/handler/JolokiaHttpHandlerTest.java
@@ -273,6 +273,21 @@ public class JolokiaHttpHandlerTest {
         assertNotNull(header.getFirst("Access-Control-Allow-Max-Age"));
     }
 
+    @Test
+    public void usingStreamingJSON() throws IOException, URISyntaxException {
+        Configuration config = getConfig(ConfigKey.STREAMING, true);
+        JolokiaHttpHandler newHandler = new JolokiaHttpHandler(config);
+        newHandler.start(false);
+
+        HttpExchange exchange = prepareExchange("http://localhost:8080/jolokia/list");
+        expect(exchange.getRequestMethod()).andReturn("GET");
+
+        Headers header = new Headers();
+        prepareResponse(newHandler, exchange, header);
+        newHandler.doHandle(exchange);
+        assertEquals(header.getFirst("Transfer-encoding"),"chunked");
+    }
+
     private HttpExchange prepareExchange(String pUri) throws URISyntaxException {
         return prepareExchange(pUri,"Origin",null);
     }

--- a/agent/jvm/src/test/java/org/jolokia/jvmagent/handler/JolokiaHttpHandlerTest.java
+++ b/agent/jvm/src/test/java/org/jolokia/jvmagent/handler/JolokiaHttpHandlerTest.java
@@ -275,7 +275,7 @@ public class JolokiaHttpHandlerTest {
 
     @Test
     public void usingStreamingJSON() throws IOException, URISyntaxException {
-        Configuration config = getConfig(ConfigKey.STREAMING, true);
+        Configuration config = getConfig(ConfigKey.STREAMING, "true");
         JolokiaHttpHandler newHandler = new JolokiaHttpHandler(config);
         newHandler.start(false);
 


### PR DESCRIPTION
This pull request implements streaming json responses. Which user can configure via jolokia properties file. 

Using streaming json I saw a drop by 39 times - in allocation sizes while an external python script performed 10 identical collections on the url. I did this numerous times and while numbers vary somewhat, it still holds true that using streaming json results in less allocations.

~~Should we choose to merge this, I will be happy to get tests sorted for the same.~~ I am also sure, I have only covered jvm-agent output and this feature probably will not work for other use cases. 

![gc-profile1](https://cloud.githubusercontent.com/assets/278/12877371/3b67cd5e-cde0-11e5-9945-a37cf8c2d859.png)
![gc-profile2](https://cloud.githubusercontent.com/assets/278/12877370/3b67a61c-cde0-11e5-8dd4-327923ba9353.png)
