### PR TITLE
Follow up to PR #21, lets use setWantClientAuth() instead of setNeedC…

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServer.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServer.java
@@ -412,8 +412,8 @@ public class JolokiaServer {
             // get the default parameters
             SSLParameters defaultSSLParameters = context.getDefaultSSLParameters();
 
-            params.setNeedClientAuth(serverConfig.useSslClientAuthentication());
-            defaultSSLParameters.setNeedClientAuth(serverConfig.useSslClientAuthentication());
+            params.setWantClientAuth(serverConfig.useSslClientAuthentication());
+            defaultSSLParameters.setWantClientAuth(serverConfig.useSslClientAuthentication());
 
             // Cipher Suites
             params.setCipherSuites(serverConfig.getSSLCipherSuites());


### PR DESCRIPTION
…lientAuth() so that you can do basic auth over SSL.  The auth will fail if client cert auth is enabled, but a valid client cert is not found.