### PR TITLE
correct the CLASSPATH in the tutorial

### DIFF
--- a/src/site/xdoc/tutorial.xml
+++ b/src/site/xdoc/tutorial.xml
@@ -87,9 +87,9 @@ public class JolokiaDemo {
         J4pReadRequest req = new J4pReadRequest("java.lang:type=Memory",
                                                 "HeapMemoryUsage");
         J4pReadResponse resp = j4pClient.execute(req);
-        Map<String,String> vals = resp.getValue();
-        int used = Integer.parseInt(vals.get("used"));
-        int max = Integer.parseInt(vals.get("max"));
+        Map<String,Long> vals = resp.getValue();
+        long used = vals.get("used");
+        long max = vals.get("max");
         int usage = (int) (used * 100 / max);
         System.out.println("Memory usage: used: " + used + 
                            " / max: " + max + " = " + usage + "%");

--- a/src/site/xdoc/tutorial.xml
+++ b/src/site/xdoc/tutorial.xml
@@ -124,8 +124,8 @@ public class JolokiaDemo {
           class. Finally, compile the demo and let it run:
         </p>
         <pre class="prettyprint lang-bash"><![CDATA[
-$ export CLASSPATH=json_simple-1.1.jar:jolokia-client-java-1.0.0.jar:\
-httpcore-4.1.2.jar:httpclient-4.1.2.jar:commons-logging-1.1.1.jar:.
+$ export CLASSPATH=json-simple-1.1.1.jar:jolokia-client-java-1.2.3.jar:\
+httpcore-4.3.3.jar:httpclient-osgi-4.3.3.jar:commons-logging-1.1.1.jar:.
 ]]>
 $ javac JolokiaDemo.java
 $ java JolokiaDemo


### PR DESCRIPTION
The tutorial for creating a simple jolokia demo application has a
mismatch between the downloaded jar files and the exported CLASSPATH.
This change corrects the classpath assignment to reflect the currently
listed jar files.