### PR TITLE
Upgrade httpclient-osgi 4.3.3 -> 4.3.6

### DIFF
--- a/client/java/pom.xml
+++ b/client/java/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.4.6</version>
+      <version>4.4.7</version>
     </dependency>
 
     <dependency>

--- a/client/java/pom.xml
+++ b/client/java/pom.xml
@@ -40,8 +40,14 @@
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
+      <artifactId>httpcore</artifactId>
       <version>4.3.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+      <version>4.3.6</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>

--- a/client/java/pom.xml
+++ b/client/java/pom.xml
@@ -41,13 +41,13 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.3.3</version>
+      <version>4.4.6</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <version>4.3.6</version>
+      <version>4.5.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Note, starting in 4.3.6, the httpcore classes are no longer bundled
with httpclient-osgi, so a separate dependency declaration is required.
See https://issues.apache.org/jira/browse/HTTPCLIENT-1558