### PR TITLE
Spring list meta

### DIFF
--- a/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringCommandHandler.java
+++ b/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringCommandHandler.java
@@ -44,4 +44,8 @@ public abstract class SpringCommandHandler<T extends JolokiaRequest> {
     }
 
     public abstract Object handleRequest(T pJmxReq, Object pPreviousResult) throws InstanceNotFoundException, AttributeNotFoundException;
+
+    protected boolean isLiteralType(Class<?> type) {
+        return type != null && (type.isAssignableFrom(Number.class) || type.isAssignableFrom(Boolean.class) || type.isAssignableFrom(String.class) || type.isAssignableFrom(Class.class));
+    }
 }

--- a/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringCommandHandler.java
+++ b/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringCommandHandler.java
@@ -44,8 +44,4 @@ public abstract class SpringCommandHandler<T extends JolokiaRequest> {
     }
 
     public abstract Object handleRequest(T pJmxReq, Object pPreviousResult) throws InstanceNotFoundException, AttributeNotFoundException;
-
-    protected boolean isLiteralType(Class<?> type) {
-        return type != null && (type.isAssignableFrom(Number.class) || type.isAssignableFrom(Boolean.class) || type.isAssignableFrom(String.class) || type.isAssignableFrom(Class.class));
-    }
 }

--- a/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringListHandler.java
+++ b/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringListHandler.java
@@ -118,7 +118,7 @@ public class SpringListHandler extends SpringCommandHandler<JolokiaListRequest> 
             Class<?> propType = propDesc.getPropertyType();
             addIfNotNull(aMap, TYPE, propType != null ? classToString(propType) : null);
             addIfNotNull(aMap, DESCRIPTION, propDesc.getShortDescription());
-            aMap.put(READ_WRITE, propDesc.getWriteMethod() != null && isLiteralType(propType));
+            aMap.put(READ_WRITE, propDesc.getWriteMethod() != null);
             ret.put(propDesc.getName(),aMap);
         }
         return ret;

--- a/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringListHandler.java
+++ b/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringListHandler.java
@@ -34,7 +34,7 @@ import static org.jolokia.service.jmx.handler.list.DataKeys.*;
 public class SpringListHandler extends SpringCommandHandler<JolokiaListRequest> {
 
     private static final String NAME_PREFIX = "name=";
-    final static Map<Class,String> WRAPPER_TO_PRIMITIVE;
+    private final static Map<Class<?>,String> WRAPPER_TO_PRIMITIVE;
 
     public SpringListHandler(ApplicationContext pAppContext, JolokiaContext pJolokiaContext) {
         super(pAppContext, pJolokiaContext, RequestType.LIST);

--- a/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringListHandler.java
+++ b/support/spring/src/main/java/org/jolokia/support/spring/backend/SpringListHandler.java
@@ -58,7 +58,9 @@ public class SpringListHandler extends SpringCommandHandler<JolokiaListRequest> 
         // TODO: Fix for FactoryBeans
         for (String beanName : appCtx.getBeanDefinitionNames()) {
             BeanDefinition bd = bdFactory.getMergedBeanDefinition(beanName);
-            ret.put("name=" + beanName, getSpringBeanInfo(bd));
+            if(!bd.isAbstract()) {// avoid abstract beans as they are not actual beans in the context
+                ret.put("name=" + beanName, getSpringBeanInfo(bd));
+            }
         }
         return ret;
     }
@@ -112,7 +114,7 @@ public class SpringListHandler extends SpringCommandHandler<JolokiaListRequest> 
         addIfNotNull(ret, DESCRIPTION, pBeanDef.getDescription());
         for (PropertyDescriptor propDesc : BeanUtils.getPropertyDescriptors(pBeanClass)) {
             JSONObject aMap = new JSONObject();
-            Class propType = propDesc.getPropertyType();
+            Class<?> propType = propDesc.getPropertyType();
             addIfNotNull(aMap, TYPE, propType != null ? classToString(propType) : null);
             addIfNotNull(aMap, DESCRIPTION, propDesc.getShortDescription());
             aMap.put(READ_WRITE, propDesc.getReadMethod() != null && propDesc.getWriteMethod() != null);


### PR DESCRIPTION
…method and kind of data

Signed-off-by: marska <martin.skarsaune@kantega.no>

Rationale: No longer test for read method, as it seems that it is taken for granted and dealt with via field reflection in the read handler. Initially make writeability limited by datatype. 
 Avoid abstract beans as they cannot be retrieved from the context and interacted with. 

Background: Not really thorough testing in the wild, but playing around with in on a few client projects. From the looks of things there are a lot of variations possible and we have probably just scratched the surface......