### PR TITLE
Add default max connection per route to "J4pClientBuilder" and replace "entity.consumeContent()"

### DIFF
--- a/client/java/pom.xml
+++ b/client/java/pom.xml
@@ -105,6 +105,22 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>1.58</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/client/java/src/main/java/org/jolokia/client/J4pClientBuilder.java
+++ b/client/java/src/main/java/org/jolokia/client/J4pClientBuilder.java
@@ -55,6 +55,7 @@ public class J4pClientBuilder {
     private int connectionTimeout;
     private int socketTimeout;
     private int maxTotalConnections;
+    private int defaultMaxConnectionsPerRoute;
     private int maxConnectionPoolTimeout;
     private Charset contentCharset;
     private boolean expectContinue;
@@ -105,6 +106,7 @@ public class J4pClientBuilder {
         connectionTimeout(20 * 1000);
         socketTimeout(-1);
         maxTotalConnections(20);
+        defaultMaxConnectionsPerRoute(20);
         maxConnectionPoolTimeout(500);
         contentCharset(HTTP.DEF_CONTENT_CHARSET.name());
         expectContinue(true);
@@ -190,7 +192,7 @@ public class J4pClientBuilder {
 
     /**
      * Use a pooled connection manager for connecting to the agent, which
-     * uses a pool of connections (see {@link #maxTotalConnections(int) and {@link #maxConnectionPoolTimeout(int)} for
+     * uses a pool of connections (see {@link #maxTotalConnections(int), {@link #maxConnectionPoolTimeout(int) {@link #defaultMaxConnectionsPerRoute}} for
      * tuning the pool}
      */
     public final J4pClientBuilder pooledConnections() {
@@ -228,6 +230,15 @@ public class J4pClientBuilder {
      */
     public final J4pClientBuilder maxTotalConnections(int pConnections) {
         maxTotalConnections = pConnections;
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of connections per route allowed when using {@link #pooledConnections()}
+     * @param pDefaultMaxConnectionsPerRoute number of max connections per route.
+     */
+    public final J4pClientBuilder defaultMaxConnectionsPerRoute(int pDefaultMaxConnectionsPerRoute) {
+        defaultMaxConnectionsPerRoute = pDefaultMaxConnectionsPerRoute;
         return this;
     }
 
@@ -494,7 +505,9 @@ public class J4pClientBuilder {
         connManager.setDefaultConnectionConfig(createConnectionConfig());
         if (maxTotalConnections != 0) {
             connManager.setMaxTotal(maxTotalConnections);
+            connManager.setDefaultMaxPerRoute(defaultMaxConnectionsPerRoute);
         }
+
         return connManager;
     }
 

--- a/client/java/src/main/java/org/jolokia/client/J4pClientBuilderFactory.java
+++ b/client/java/src/main/java/org/jolokia/client/J4pClientBuilderFactory.java
@@ -69,6 +69,11 @@ public abstract class J4pClientBuilderFactory {
         return new J4pClientBuilder().maxTotalConnections(pConnections);
     }
 
+    /** See {@link J4pClientBuilder#defaultMaxConnectionsPerRoute(int)} */
+    public static J4pClientBuilder defaultMaxConnectionsPerRoute(int pConnectionsPerRoute) {
+        return new J4pClientBuilder().defaultMaxConnectionsPerRoute(pConnectionsPerRoute);
+    }
+
     /** See {@link J4pClientBuilder#maxConnectionPoolTimeout(int)} */
     public static J4pClientBuilder maxConnectionPoolTimeout(int pConnectionPoolTimeout) {
         return new J4pClientBuilder().maxConnectionPoolTimeout(pConnectionPoolTimeout);

--- a/client/java/src/main/java/org/jolokia/client/request/J4pRequestHandler.java
+++ b/client/java/src/main/java/org/jolokia/client/request/J4pRequestHandler.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import org.apache.http.*;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
 import org.json.simple.*;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -161,7 +162,7 @@ public class J4pRequestHandler {
             }
         } finally {
             if (entity != null) {
-                entity.consumeContent();
+                EntityUtils.consume(entity);
             }
         }
     }

--- a/client/java/src/test/java/org/jolokia/client/J4pClientBuilderTest.java
+++ b/client/java/src/test/java/org/jolokia/client/J4pClientBuilderTest.java
@@ -45,6 +45,7 @@ public class J4pClientBuilderTest {
                         .contentCharset("utf-8")
                         .maxConnectionPoolTimeout(3000)
                         .maxTotalConnections(500)
+                        .defaultMaxConnectionsPerRoute(500)
                         .pooledConnections()
                         .socketBufferSize(8192)
                         .socketTimeout(5000)
@@ -68,6 +69,7 @@ public class J4pClientBuilderTest {
         assertNotNull(J4pClient.socketBufferSize(8192));
         assertNotNull(J4pClient.socketTimeout(5000));
         assertNotNull(J4pClient.cookieStore(new BasicCookieStore()));
+        assertNotNull(J4pClient.defaultMaxConnectionsPerRoute(100));
     }
 
     @Test

--- a/client/java/src/test/java/org/jolokia/client/J4pClientTest.java
+++ b/client/java/src/test/java/org/jolokia/client/J4pClientTest.java
@@ -184,7 +184,6 @@ public class J4pClientTest {
         final ByteArrayInputStream bis =
                 new ByteArrayInputStream(jsonResp.getBytes());
         expect(entity.getContent()).andReturn(bis);
-        //EntityUtils.consume(entity);
         replay(client, response, entity);
         return client;
     }

--- a/client/java/src/test/java/org/jolokia/client/J4pClientTest.java
+++ b/client/java/src/test/java/org/jolokia/client/J4pClientTest.java
@@ -27,6 +27,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
 import org.easymock.EasyMock;
 import org.jolokia.client.exception.*;
 import org.jolokia.client.request.*;
@@ -115,8 +116,8 @@ public class J4pClientTest {
         expect(client.execute(EasyMock.<HttpUriRequest>anyObject())).andReturn(response);
         expect(response.getEntity()).andReturn(entity);
         expect(entity.getContentEncoding()).andReturn(null);
+        expect(entity.isStreaming()).andReturn(false);
         expect(entity.getContent()).andThrow(new IOException());
-        entity.consumeContent();
         replay(client, entity, response);
 
         J4pClient j4p = new J4pClient(TEST_URL,client);
@@ -177,12 +178,13 @@ public class J4pClientTest {
         HttpEntity entity = createMock(HttpEntity.class);
         expect(client.execute(EasyMock.<HttpUriRequest>anyObject())).andReturn(response);
         expect(response.getEntity()).andReturn(entity);
+        expect(entity.isStreaming()).andReturn(false);
         expect(entity.getContentEncoding()).andReturn(encoding != null ? new BasicHeader("Content-Encoding",encoding) : null);
 
         final ByteArrayInputStream bis =
                 new ByteArrayInputStream(jsonResp.getBytes());
         expect(entity.getContent()).andReturn(bis);
-        entity.consumeContent();
+        //EntityUtils.consume(entity);
         replay(client, response, entity);
         return client;
     }

--- a/client/java/src/test/java/org/jolokia/client/request/J4pConnectionPoolingIntegrationTest.java
+++ b/client/java/src/test/java/org/jolokia/client/request/J4pConnectionPoolingIntegrationTest.java
@@ -1,0 +1,134 @@
+package org.jolokia.client.request;
+
+/*
+ * Copyright 2009-2017 Baris Cubukcuoglu
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.Options;
+import org.apache.http.conn.ConnectionPoolTimeoutException;
+import org.jolokia.client.J4pClient;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.management.ObjectName;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.testng.AssertJUnit.*;
+
+public class J4pConnectionPoolingIntegrationTest {
+
+    private WireMockServer wireMockServer;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        wireMockServer = new WireMockServer(Options.DYNAMIC_PORT);
+        wireMockServer.start();
+    }
+
+    @Test
+    public void testSearchParallelWithConnectionPoolException() throws Exception {
+        configureFor("localhost", wireMockServer.port());
+        final J4pClient j4pClient = createJ4pClient("http://localhost:" + wireMockServer.port() + "/test", 20, 2);
+        try {
+            searchParallel(j4pClient);
+            fail();
+        } catch (ExecutionException executionException) {
+            assertEquals(ConnectionPoolTimeoutException.class, executionException.getCause().getCause().getClass());
+        }
+
+    }
+
+    @Test
+    public void testSearchParallel() throws Exception {
+        configureFor("localhost", wireMockServer.port());
+        final J4pClient j4pClient = createJ4pClient("http://localhost:" + wireMockServer.port() + "/test", 20, 20);
+        searchParallel(j4pClient);
+
+        verify(20, getRequestedFor(urlPathMatching("/test/([a-z]*)")));
+    }
+
+    private void searchParallel(J4pClient j4pClient) throws Exception {
+        stubFor(get(urlPathMatching("/test/([a-z]*)")).willReturn(aResponse().withFixedDelay(1000).withBody(getJsonResponse("test"))));
+
+        final ExecutorService executorService = Executors.newFixedThreadPool(20);
+        final J4pSearchRequest j4pSearchRequest = new J4pSearchRequest("java.lang:type=*");
+
+        final List<Future<Void>> requestsList = new ArrayList<Future<Void>>();
+
+        for (int i = 0; i < 20; i++) {
+            requestsList.add(executorService.submit(new AsyncRequest(j4pClient, j4pSearchRequest)));
+        }
+
+        for (Future<Void> requests : requestsList) {
+            requests.get();
+        }
+
+        executorService.shutdown();
+    }
+
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        wireMockServer.stop();
+    }
+
+    private J4pClient createJ4pClient(String url, int maxTotalConnections, int connectionsPerRoute) {
+        return J4pClient.url(url)
+                .pooledConnections()
+                .maxTotalConnections(maxTotalConnections)
+                .defaultMaxConnectionsPerRoute(connectionsPerRoute)
+                .build();
+    }
+
+    static class AsyncRequest implements Callable<Void> {
+        private final J4pClient j4pClient;
+        private final J4pSearchRequest j4pSearchRequest;
+
+        public AsyncRequest(J4pClient j4pClient, J4pSearchRequest j4pSearchRequest) {
+            this.j4pClient = j4pClient;
+            this.j4pSearchRequest = j4pSearchRequest;
+        }
+
+        public Void call() throws Exception {
+            J4pSearchResponse resp = j4pClient.execute(j4pSearchRequest);
+            assertNotNull(resp);
+            List<ObjectName> names = resp.getObjectNames();
+            assertTrue(names.contains(new ObjectName("java.lang:type=Memory")));
+            return null;
+        }
+    }
+
+    private String getJsonResponse(String message) {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final ObjectNode node = objectMapper.createObjectNode();
+
+        final ArrayNode arrayNode = objectMapper.createArrayNode();
+        arrayNode.add("java.lang:type=Memory");
+        node.putArray("value").addAll(arrayNode);
+
+        node.put("status", 200);
+        node.put("timestamp", 1244839118);
+
+        return node.toString();
+    }
+}

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -23,6 +23,11 @@
     <author email="roland@jolokia.org">Roland Huß</author>
   </properties>
   <body>
+    <release version="1.3.8" description="Release 1.3.8">
+      <action dev="bcubk" type="fix" issue="309">
+        Support "max connection per route" setting for J4pClientBuilder to prevent a ConnectionPoolTimeoutException
+      </action>
+    </release>
     <release version="1.3.7" description="Release 1.3.7" date="2017-07-06">
       <action dev="rhuss" type="fix" date="2017-05-17" issue="198">
         Support attaching to running JVM even when -XX:+PerfDisableSharedMem is given

--- a/src/docbkx/client/java.xml
+++ b/src/docbkx/client/java.xml
@@ -254,6 +254,15 @@ J4pClient j4p = J4pClient.url("http://localhost:8080/jolokia")
         <td>20</td>
       </tr>
       <tr>
+        <td><constant>defaultMaxConnectionsPerRoute</constant></td>
+        <td>
+          Defines the number of total connections per route. It
+          is only used when <constant>pooledConnection</constant> is
+          used.
+        </td>
+        <td>20</td>
+      </tr>
+      <tr>
         <td><constant>maxConnectionPoolTimeout</constant></td>
         <td>
           Defines the timeout for waiting to obtain a connection


### PR DESCRIPTION
This PR enhance to J4PClientBuilder and adds a method to define the max connection per route for Apache HTTPClient. This prevents a possible ConnectionPoolTimeoutException with an high amount of HTTP requests. This setting is necessary, because Apache HTTPClients ClientConnectionPoolManager maintains a maximum limit of connection on a per route basis and in total. 

To reproduce this bug, I use Wiremock to define a reliable testcase with an pre-defined fixed delay.   

This PR replaces "entity.consumeContent()" with "EntityUtils.consume(entity)" because it's deprecated.

Fixes #309 and #287