### PR TITLE
Adding LightStreamer Detector

### DIFF
--- a/agent/core/src/main/java/org/jolokia/detector/LightstreamerDetector.java
+++ b/agent/core/src/main/java/org/jolokia/detector/LightstreamerDetector.java
@@ -1,0 +1,68 @@
+package org.jolokia.detector;
+
+import java.lang.instrument.Instrumentation;
+import org.jolokia.backend.executor.MBeanServerExecutor;
+
+public class LightstreamerDetector extends AbstractServerDetector {
+
+
+    /** {@inheritDoc}
+     * @param pMBeanServerExecutor*/
+    public ServerHandle detect(MBeanServerExecutor pMBeanServerExecutor) {
+        String serverVersion = getSingleStringAttribute(pMBeanServerExecutor, "com.lightstreamer:type=Server", "LSVersion");
+        if (serverVersion != null) {
+            return new ServerHandle("LightStreamer", "LightStreamer", serverVersion, null);
+        }
+        return null;
+    }
+
+    @Override
+    public void jvmAgentStartup(Instrumentation instrumentation) {
+        if (isLightStreamer(instrumentation)) {
+            awaitLightstreamerMBeans(instrumentation);
+        }
+    }
+    
+    protected boolean isLightStreamer(Instrumentation instrumentation) {
+        for (String name : System.getProperties().stringPropertyNames()) {
+            if (name.contains("com.lightstreamer")) {
+                return true;
+            }
+        }
+        for (Class loadedClass : instrumentation.getAllLoadedClasses()) {
+            if (loadedClass.getCanonicalName().contains("com.lightstreamer")) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public static final int LIGHTSTREAMER_DETECT_TIMEOUT = 5 * 60 * 1000;
+    public static final int LIGHTSTREAMER_DETECT_INTERVAL = 200;
+    public static final int LIGHTSTREAMER_DETECT_FINAL_DELAY = 500;
+    public static final String LIGHTSTREAMER_MBEAN_CLASS = "com.lightstreamer.jmx.ServerMBean";
+
+    private void awaitLightstreamerMBeans(Instrumentation instrumentation) {
+        int count = 0;
+        while (count * LIGHTSTREAMER_DETECT_INTERVAL < LIGHTSTREAMER_DETECT_TIMEOUT) {
+            boolean serverMBean = isClassLoaded(LIGHTSTREAMER_MBEAN_CLASS, instrumentation);
+            if (serverMBean) {
+                try {
+                    Thread.sleep(LIGHTSTREAMER_DETECT_FINAL_DELAY);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return;
+            }
+            
+            try {
+                Thread.sleep(LIGHTSTREAMER_DETECT_INTERVAL);
+                count++;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new IllegalStateException(String.format("Detected Lightstreamer, but JMX MBeans were not loaded after %d seconds", LIGHTSTREAMER_DETECT_TIMEOUT / 1000));
+    }
+    
+}

--- a/agent/core/src/main/resources/META-INF/detectors-default
+++ b/agent/core/src/main/resources/META-INF/detectors-default
@@ -6,4 +6,4 @@ org.jolokia.detector.JettyDetector
 org.jolokia.detector.GlassfishDetector
 org.jolokia.detector.WeblogicDetector
 org.jolokia.detector.WebsphereDetector
-
+org.jolokia.detector.LightstreamerDetector

--- a/agent/core/src/test/java/org/jolokia/detector/LightstreamerDetectorTest.java
+++ b/agent/core/src/test/java/org/jolokia/detector/LightstreamerDetectorTest.java
@@ -1,0 +1,61 @@
+package org.jolokia.detector;
+
+import java.lang.instrument.Instrumentation;
+import java.util.Arrays;
+import java.util.HashSet;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+public class LightstreamerDetectorTest extends BaseDetectorTest {
+
+    LightstreamerDetector detector = new LightstreamerDetector();
+
+    @Test
+    public void testDetect() throws MalformedObjectNameException, AttributeNotFoundException, MBeanException, ReflectionException, InstanceNotFoundException {
+        String version = "6.0.1";
+        MBeanServer mockServer = createMock(MBeanServer.class);
+        ObjectName oName = new ObjectName("com.lightstreamer:type=Server");
+        expect(mockServer.queryNames(new ObjectName("com.lightstreamer:type=Server"), null)).
+                andReturn(new HashSet<ObjectName>(Arrays.asList(oName))).anyTimes();
+        expect(mockServer.isRegistered(oName)).andStubReturn(true);
+        expect(mockServer.getAttribute(oName,"LSVersion")).andStubReturn(version);
+        replay(mockServer);
+
+        ServerHandle handle = detector.detect(getMBeanServerManager(mockServer));
+        assertNotNull(handle);
+        assertEquals(handle.getVersion(),version);
+    }
+    
+    @Test
+    public void testIsLightStreamer_NotFound() {
+        Instrumentation mockInstrumentation = createMock(Instrumentation.class);
+        expect(mockInstrumentation.getAllLoadedClasses()).andReturn(new Class[0]);
+        replay(mockInstrumentation);
+        assertFalse(detector.isLightStreamer(mockInstrumentation));
+    }
+    
+    @Test
+    public void testIsLightStreamer_SystemPropertyFound() {
+        String systemPropertyName = "com.lightstreamer.kernel_lib_path";
+        System.setProperty(systemPropertyName, "path");
+        try {
+            Instrumentation mockInstrumentation = createMock(Instrumentation.class);
+            assertTrue(detector.isLightStreamer(mockInstrumentation));
+        } finally {
+            System.clearProperty(systemPropertyName);
+        }
+    }
+}


### PR DESCRIPTION
- LightStreamer starts its own MBean server for internal metrics
- The Jolokia plugin is intermittent in picking the MBeans up due to startup timing issues between the JavaAgent and the MBean Server
- The detector will look for System Properties or Classes which belong to LightStreamer and if present delay the MBean scanning until the LightStreamer MBean classes have been loaded

Signed-off-by: Alexander Gordon <alexander.gordon@ig.com>