### PR TITLE
Give discovery threads names to indicate ownership

### DIFF
--- a/agent/core/src/main/java/org/jolokia/discovery/DiscoveryMulticastResponder.java
+++ b/agent/core/src/main/java/org/jolokia/discovery/DiscoveryMulticastResponder.java
@@ -74,7 +74,8 @@ public class DiscoveryMulticastResponder {
             // We start a thread for every address found
             for (InetAddress addr : addresses) {
                 try {
-                    MulticastSocketListenerThread thread = new MulticastSocketListenerThread(addr,
+                    MulticastSocketListenerThread thread = new MulticastSocketListenerThread("JolokiaDiscoveryListenerThread-" + addr.getHostAddress(),
+                                                                                            addr,
                                                                                              detailsHolder,
                                                                                              restrictor,
                                                                                              logHandler);

--- a/agent/core/src/main/java/org/jolokia/discovery/MulticastSocketListenerThread.java
+++ b/agent/core/src/main/java/org/jolokia/discovery/MulticastSocketListenerThread.java
@@ -48,7 +48,8 @@ class MulticastSocketListenerThread extends Thread {
      *                    the address from which the packet was received.
      * @param pLogHandler log handler used for logging
      */
-    MulticastSocketListenerThread(InetAddress pHostAddress, AgentDetailsHolder pAgentDetailsHolder, Restrictor pRestrictor, LogHandler pLogHandler) throws IOException {
+    MulticastSocketListenerThread(String name, InetAddress pHostAddress, AgentDetailsHolder pAgentDetailsHolder, Restrictor pRestrictor, LogHandler pLogHandler) throws IOException {
+        super(name);
         address = pHostAddress != null ? pHostAddress : NetworkUtil.getLocalAddressWithMulticast();
         agentDetailsHolder = pAgentDetailsHolder;
         restrictor = pRestrictor;

--- a/agent/core/src/test/java/org/jolokia/discovery/MulticastSocketListenerThreadTest.java
+++ b/agent/core/src/test/java/org/jolokia/discovery/MulticastSocketListenerThreadTest.java
@@ -38,7 +38,7 @@ public class MulticastSocketListenerThreadTest {
         details.setSecured(false);
         details.setServerInfo("jolokia", "jolokia-test", "1.0");
 
-        MulticastSocketListenerThread listenerThread = new MulticastSocketListenerThread(null,
+        MulticastSocketListenerThread listenerThread = new MulticastSocketListenerThread("ListenerThread", null,
                                                getAgentDetailsHolder(details),
                                                new AllowAllRestrictor(),
                                                new LogHandler.StdoutLogHandler(true));


### PR DESCRIPTION
Signed-off-by: marska <martin.skarsaune@kantega.no>

The muliticast socket listener (discovery) threads have generic names Thread-n . As jolokia runs as an agent it should mark ownership of these threads to avoid unneccesary confusion:
![image](https://user-images.githubusercontent.com/6298906/31152841-37113df4-a89e-11e7-88cc-29f9a940d00f.png)

Suggestion: prefix threads with JolokiaDiscoveryListenerThread to state what they are:
![image](https://user-images.githubusercontent.com/6298906/31152877-5fb73a6a-a89e-11e7-86a9-c8ab9085891e.png)

There are still 2 generically named threads from com.sun.net.httpserver, but there does not seem to be any good way to affect this as the thread is instantiated inside the server source. 
