### PR TITLE
Add "service" authMode to jolokia-osgi

### DIFF
--- a/agent/core/src/main/java/org/jolokia/config/ConfigKey.java
+++ b/agent/core/src/main/java/org/jolokia/config/ConfigKey.java
@@ -210,7 +210,7 @@ public enum ConfigKey {
 
     /**
      * What authentication to use. Support values: "basic" for basic authentication, "jaas" for
-     * JaaS authentication.
+     * JaaS authentication, "service" to use Authenticator provided via Service Registry
      */
     AUTH_MODE("authMode", true, false, "basic"),
 

--- a/agent/core/src/main/java/org/jolokia/config/ConfigKey.java
+++ b/agent/core/src/main/java/org/jolokia/config/ConfigKey.java
@@ -210,7 +210,9 @@ public enum ConfigKey {
 
     /**
      * What authentication to use. Support values: "basic" for basic authentication, "jaas" for
-     * JaaS authentication, "service" to use Authenticator provided via Service Registry
+     * JaaS authentication, "delegate" for delegating to another HTTP service.
+     * For OSGi agent there are the additional modes "service-all" and "service-any" to use Authenticator services
+     * provided via an OSGi service registry.
      */
     AUTH_MODE("authMode", true, false, "basic"),
 

--- a/agent/osgi/pom.xml
+++ b/agent/osgi/pom.xml
@@ -116,6 +116,7 @@
               jolokia-jsr160;inline=true
             </Embed-Dependency>
             <Export-Package>
+              org.jolokia.osgi.security;version="${project.version}",
               org.jolokia.osgi.servlet;uses:="org.osgi.service.http,org.osgi.framework,javax.servlet";version="${project.version}",
               org.jolokia.restrictor;uses:="javax.management,javax.xml.parsers,org.w3c.dom,org.xml.sax";version="${project.version}",
               org.jolokia.util;version="${project.version}",

--- a/agent/osgi/src/main/java/org/jolokia/osgi/JolokiaActivator.java
+++ b/agent/osgi/src/main/java/org/jolokia/osgi/JolokiaActivator.java
@@ -12,13 +12,13 @@ import org.jolokia.config.ConfigKey;
 import org.jolokia.osgi.security.*;
 import org.jolokia.osgi.servlet.JolokiaContext;
 import org.jolokia.osgi.servlet.JolokiaServlet;
+import org.jolokia.osgi.util.LogHelper;
 import org.jolokia.restrictor.Restrictor;
 import org.jolokia.util.NetworkUtil;
 import org.osgi.framework.*;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.http.*;
-import org.osgi.service.log.LogService;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
@@ -149,14 +149,15 @@ public class JolokiaActivator implements BundleActivator, JolokiaContext {
             final String user = getConfiguration(USER);
             final String authMode = getConfiguration(AUTH_MODE);
             if (user == null) {
-                if (!authMode.equalsIgnoreCase("service")) {
-                    jolokiaHttpContext = new DefaultHttpContext();
+                if (ServiceAuthenticationHttpContext.shouldBeUsed(authMode)) {
+                    jolokiaHttpContext = new ServiceAuthenticationHttpContext(bundleContext, authMode);
                 } else {
-                    jolokiaHttpContext = new ServiceAuthenticationHttpContext(bundleContext);
+                    jolokiaHttpContext = new DefaultHttpContext();
                 }
             } else {
-                jolokiaHttpContext = new BasicAuthenticationHttpContext(getConfiguration(REALM),
-                        createAuthenticator());
+                jolokiaHttpContext =
+                    new BasicAuthenticationHttpContext(getConfiguration(REALM),
+                                                       createAuthenticator(authMode));
             }
         }
         return jolokiaHttpContext;
@@ -235,12 +236,12 @@ public class JolokiaActivator implements BundleActivator, JolokiaContext {
         }
     }
 
-    private Authenticator createAuthenticator() {
+    private Authenticator createAuthenticator(String authMode) {
         Authenticator authenticator = createCustomAuthenticator();
-        if (authenticator == null) {
-            authenticator = createAuthenticatorFromAuthMode();
+        if (authenticator != null) {
+            return authenticator;
         }
-        return authenticator;
+        return createAuthenticatorFromAuthMode(authMode);
     }
 
     private Authenticator createCustomAuthenticator() {
@@ -297,17 +298,14 @@ public class JolokiaActivator implements BundleActivator, JolokiaContext {
         }
     }
 
-    private Authenticator createAuthenticatorFromAuthMode() {
-        Authenticator authenticator;
-        final String authMode = getConfiguration(AUTH_MODE);
-        if ("basic".equalsIgnoreCase(authMode)) {
-            authenticator = new BasicAuthenticator(getConfiguration(USER),getConfiguration(PASSWORD));
-        } else if ("jaas".equalsIgnoreCase(authMode)) {
-            authenticator = new JaasAuthenticator(getConfiguration(REALM));
+    private Authenticator createAuthenticatorFromAuthMode(String pAuthMode) {
+        if ("basic".equalsIgnoreCase(pAuthMode)) {
+            return new BasicAuthenticator(getConfiguration(USER),getConfiguration(PASSWORD));
+        } else if ("jaas".equalsIgnoreCase(pAuthMode)) {
+            return new JaasAuthenticator(getConfiguration(REALM));
         } else {
-            throw new IllegalArgumentException("Unknown authentication method '" + authMode + "' configured");
+            throw new IllegalArgumentException("Unknown authentication method '" + pAuthMode + "' configured");
         }
-        return authenticator;
     }
 
     // =============================================================================
@@ -328,9 +326,9 @@ public class JolokiaActivator implements BundleActivator, JolokiaContext {
                                         getConfiguration(),
                                         getHttpContext());
             } catch (ServletException e) {
-                logError("Servlet Exception: " + e, e);
+                LogHelper.logError(bundleContext, "Servlet Exception: " + e, e);
             } catch (NamespaceException e) {
-                logError("Namespace Exception: " + e, e);
+                LogHelper.logError(bundleContext, "Namespace Exception: " + e, e);
             }
             return service;
         }
@@ -344,23 +342,6 @@ public class JolokiaActivator implements BundleActivator, JolokiaContext {
             HttpService httpService = (HttpService) service;
             httpService.unregister(getServletAlias());
         }
-    }
-
-    @SuppressWarnings("PMD.SystemPrintln")
-    private void logError(String message,Throwable throwable) {
-        ServiceReference lRef = bundleContext.getServiceReference(LogService.class.getName());
-        if (lRef != null) {
-            try {
-                LogService logService = (LogService) bundleContext.getService(lRef);
-                if (logService != null) {
-                    logService.log(LogService.LOG_ERROR,message,throwable);
-                    return;
-                }
-            } finally {
-                bundleContext.ungetService(lRef);
-            }
-        }
-        System.err.println("Jolokia-Error: " + message + " : " + throwable.getMessage());
     }
 
 }

--- a/agent/osgi/src/main/java/org/jolokia/osgi/security/Authenticator.java
+++ b/agent/osgi/src/main/java/org/jolokia/osgi/security/Authenticator.java
@@ -3,33 +3,17 @@ package org.jolokia.osgi.security;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * Interface used for performing the authentication.
+ * Interface used for authentication. Can be implemented externally, too.
  *
  * @author roland
- * @since 26.05.14
+ * @since 07.02.18
  */
-public abstract class Authenticator {
+public interface Authenticator {
 
     /**
      * Authenticate the given request
      * @param pRequest request to examine
      * @return true if authentication passes, false otherwise
      */
-    boolean authenticate(HttpServletRequest pRequest) {
-        String auth = pRequest.getHeader("Authorization");
-        if (auth == null) {
-            return false;
-        }
-        AuthorizationHeaderParser.Result authInfo = AuthorizationHeaderParser.parse(auth);
-        return authInfo.isValid() && doAuthenticate(pRequest, authInfo);
-    }
-
-    /**
-     * Overriden by concrete implementations for doing the real authentication
-     *
-     * @param pRequest request which can be used to store additional authentication information
-     * @param pAuthInfo authentication information provided by the user
-     * @return true if authentication is ok, false otherwise
-     */
-    protected abstract boolean doAuthenticate(HttpServletRequest pRequest, AuthorizationHeaderParser.Result pAuthInfo);
+    boolean authenticate(HttpServletRequest pRequest);
 }

--- a/agent/osgi/src/main/java/org/jolokia/osgi/security/BaseAuthenticator.java
+++ b/agent/osgi/src/main/java/org/jolokia/osgi/security/BaseAuthenticator.java
@@ -1,0 +1,35 @@
+package org.jolokia.osgi.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Interface used for performing the authentication.
+ *
+ * @author roland
+ * @since 26.05.14
+ */
+public abstract class BaseAuthenticator implements Authenticator {
+
+    /**
+     * Authenticate the given request
+     * @param pRequest request to examine
+     * @return true if authentication passes, false otherwise
+     */
+    public boolean authenticate(HttpServletRequest pRequest) {
+        String auth = pRequest.getHeader("Authorization");
+        if (auth == null) {
+            return false;
+        }
+        AuthorizationHeaderParser.Result authInfo = AuthorizationHeaderParser.parse(auth);
+        return authInfo.isValid() && doAuthenticate(pRequest, authInfo);
+    }
+
+    /**
+     * Overriden by concrete implementations for doing the real authentication
+     *
+     * @param pRequest request which can be used to store additional authentication information
+     * @param pAuthInfo authentication information provided by the user
+     * @return true if authentication is ok, false otherwise
+     */
+    abstract protected boolean doAuthenticate(HttpServletRequest pRequest, AuthorizationHeaderParser.Result pAuthInfo);
+}

--- a/agent/osgi/src/main/java/org/jolokia/osgi/security/BasicAuthenticator.java
+++ b/agent/osgi/src/main/java/org/jolokia/osgi/security/BasicAuthenticator.java
@@ -9,7 +9,7 @@ import org.osgi.service.http.HttpContext;
 * @since 26.05.14
 */
 
-public class BasicAuthenticator extends Authenticator {
+public class BasicAuthenticator extends BaseAuthenticator {
 
     private final String userToCheck;
     private final String passwordToCheck;

--- a/agent/osgi/src/main/java/org/jolokia/osgi/security/JaasAuthenticator.java
+++ b/agent/osgi/src/main/java/org/jolokia/osgi/security/JaasAuthenticator.java
@@ -12,7 +12,7 @@ import org.osgi.service.http.HttpContext;
  * @author roland
  * @since 26.05.14
  */
-public class JaasAuthenticator extends Authenticator {
+public class JaasAuthenticator extends BaseAuthenticator {
 
     private final String realm;
 

--- a/agent/osgi/src/main/java/org/jolokia/osgi/security/ServiceAuthenticationHttpContext.java
+++ b/agent/osgi/src/main/java/org/jolokia/osgi/security/ServiceAuthenticationHttpContext.java
@@ -1,0 +1,140 @@
+package org.jolokia.osgi.security;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogService;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/*
+ * Copyright 2017 Ryan Goulding
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Authentication context based on an Authenticator Service.
+ */
+public class ServiceAuthenticationHttpContext extends DefaultHttpContext {
+
+    private volatile Set<Authenticator> authenticators = new HashSet();
+
+    private ServiceTracker authenticatorServiceTracker;
+
+    public ServiceAuthenticationHttpContext(final BundleContext bundleContext) {
+        authenticatorServiceTracker = new ServiceTracker(bundleContext, Authenticator.class.getName(),
+                new AuthenticatorServiceCustomizer(bundleContext));
+        authenticatorServiceTracker.open();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean handleSecurity(final HttpServletRequest request, final HttpServletResponse response)
+            throws IOException {
+
+        synchronized(authenticators) {
+            // deny access if authMode is set to service but a service is not provided
+            if (authenticators.isEmpty()) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                return false;
+            }
+            for (final Authenticator authenticator : authenticators) {
+                if (!authenticator.authenticate(request)) {
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    public void close() {
+        if (authenticatorServiceTracker != null) {
+            authenticatorServiceTracker.close();
+            authenticatorServiceTracker = null;
+        }
+    }
+
+
+    // =============================================================================
+
+    private class AuthenticatorServiceCustomizer implements ServiceTrackerCustomizer {
+
+        private final BundleContext bundleContext;
+
+        AuthenticatorServiceCustomizer(final BundleContext bundleContext) {
+            this.bundleContext = bundleContext;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public Object addingService(ServiceReference serviceReference) {
+            final Object service = bundleContext.getService(serviceReference);
+            try {
+                synchronized (authenticators) {
+                    authenticators.add((Authenticator) service);
+                    return authenticators;
+                }
+            } catch (final ClassCastException e) {
+                logError("Unable to use provided Authenticator", e);
+            }
+            return null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void modifiedService(final ServiceReference serviceReference, final Object service) {
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public void removedService(final ServiceReference serviceReference, final Object service) {
+            synchronized (authenticators) {
+                bundleContext.ungetService(serviceReference);
+                authenticators.remove(service);
+            }
+        }
+
+        @SuppressWarnings("PMD.SystemPrintln")
+        private void logError(final String message, final Throwable throwable) {
+            final BundleContext bundleContext = FrameworkUtil
+                    .getBundle(ServiceAuthenticationHttpContext.class)
+                    .getBundleContext();
+            final ServiceReference lRef = bundleContext.getServiceReference(LogService.class.getName());
+            if (lRef != null) {
+                try {
+                    final LogService logService = (LogService) bundleContext.getService(lRef);
+                    if (logService != null) {
+                        logService.log(LogService.LOG_ERROR, message, throwable);
+                        return;
+                    }
+                } finally {
+                    bundleContext.ungetService(lRef);
+                }
+            }
+            System.err.println("Jolokia-Error: " + message + " : " + throwable.getMessage());
+        }
+    }
+}

--- a/agent/osgi/src/main/java/org/jolokia/osgi/util/LogHelper.java
+++ b/agent/osgi/src/main/java/org/jolokia/osgi/util/LogHelper.java
@@ -1,0 +1,55 @@
+package org.jolokia.osgi.util;
+
+import org.jolokia.osgi.security.ServiceAuthenticationHttpContext;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogService;
+
+/**
+ * Helper class for logging errors
+ *
+ * @author roland
+ * @since 06.02.18
+ */
+public class LogHelper {
+
+
+    /**
+     * Log error to a logging service (if available), otherwise log to std error
+     *
+     * @param pMessage message to log
+     * @param pThrowable an exception to log
+     */
+    public static void logError(String pMessage, Throwable pThrowable) {
+        final BundleContext bundleContext = FrameworkUtil
+            .getBundle(ServiceAuthenticationHttpContext.class)
+            .getBundleContext();
+        logError(bundleContext, pMessage, pThrowable);
+    }
+
+
+    /**
+     * Log error to a logging service (if available), otherwise log to std error
+     *
+     * @param pBundleContext bundle context to lookup LogService
+     * @param pMessage message to log
+     * @param pThrowable an exception to log
+     */
+    public static void logError(BundleContext pBundleContext, String pMessage, Throwable pThrowable) {
+
+        final ServiceReference lRef = pBundleContext.getServiceReference(LogService.class.getName());
+        if (lRef != null) {
+            try {
+                final LogService logService = (LogService) pBundleContext.getService(lRef);
+                if (logService != null) {
+                    logService.log(LogService.LOG_ERROR, pMessage, pThrowable);
+                    return;
+                }
+            } finally {
+                pBundleContext.ungetService(lRef);
+            }
+        }
+        System.err.println("Jolokia-Error: " + pMessage + " : " + pThrowable.getMessage());
+    }
+}

--- a/agent/osgi/src/test/java/org/jolokia/osgi/security/ServiceAuthenticationHttpContextTest.java
+++ b/agent/osgi/src/test/java/org/jolokia/osgi/security/ServiceAuthenticationHttpContextTest.java
@@ -1,0 +1,153 @@
+package org.jolokia.osgi.security;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceReference;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isNull;
+import static org.easymock.EasyMock.replay;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * @author roland
+ * @since 07.02.18
+ */
+public class ServiceAuthenticationHttpContextTest {
+
+
+    @Test
+    public void checkEmptyAny() throws Exception {
+        checkEmpty(ServiceAuthenticationHttpContext.AUTHMODE_SERVICE_ANY);
+    }
+
+    @Test
+    public void checkEmptyAll() throws Exception {
+        checkEmpty(ServiceAuthenticationHttpContext.AUTHMODE_SERVICE_ALL);
+    }
+
+    @Test
+    public void checkEmptyInvalid() throws Exception {
+        try {
+            checkEmpty("bla");
+            fail();
+        } catch (IllegalArgumentException exp) {
+            assertTrue(exp.getMessage().contains("bla"));
+        }
+    }
+
+    private void checkEmpty(String mode) throws IOException, InvalidSyntaxException {
+        BundleContext bundleContext = createBundleContext();
+        expect(bundleContext.getServiceReferences(eq(Authenticator.class.getName()), (String) isNull())).andReturn(null);
+        replay(bundleContext);
+        ServiceAuthenticationHttpContext ctx = createContext(bundleContext, mode);
+        HttpServletResponse resp = prepareResponse();
+        assertFalse(ctx.handleSecurity(null, resp));
+    }
+
+    @Test
+    public void anyAuthenticator() throws Exception {
+        Object[] testData = new Object[]{
+            "service-any", new boolean[]{true, false}, true,
+            "service-all", new boolean[]{true, false}, false,
+            "service-any", new boolean[]{true, true}, true,
+            "service-all", new boolean[]{true, true}, true,
+            "service-any", new boolean[]{false, false}, false,
+            "service-all", new boolean[]{false, false}, false,
+            "service-any", new boolean[]{false, true}, true,
+            "service-all", new boolean[]{false, true}, false,
+            "service-all", new boolean[]{true, true, true, true, false, true}, false,
+            "service-any", new boolean[]{false, false, false, false, false, true}, true
+        };
+
+        for (int i = 0; i < testData.length; i += 3) {
+            BundleContext bundleContext = createBundleContext();
+            ServiceReference[] serviceRefs = createServiceReferences(bundleContext, (boolean[]) testData[i + 1]);
+
+            expect(bundleContext.getServiceReferences(eq(Authenticator.class.getName()), (String) isNull())).andReturn(serviceRefs);
+            replay(bundleContext);
+
+            ServiceAuthenticationHttpContext ctx = createContext(bundleContext, (String) testData[i]);
+            HttpServletResponse resp = prepareResponse();
+            assertEquals(ctx.handleSecurity(null, resp), testData[i + 2],
+                         String.format("%s: %s --> %s", testData[i], printBooleanList((boolean[]) testData[i + 1]), testData[i + 2]));
+        }
+    }
+
+    private BundleContext createBundleContext() throws InvalidSyntaxException {
+        BundleContext bundleContext = createMock(BundleContext.class);
+        expect(bundleContext.createFilter((String) anyObject())).andReturn(null);
+        bundleContext.addServiceListener((ServiceListener) anyObject(), (String) anyObject());
+        return bundleContext;
+    }
+
+    @Test
+    public void checkClose() throws Exception {
+        BundleContext bundleContext = createBundleContext();
+        expect(bundleContext.getServiceReferences(eq(Authenticator.class.getName()), (String) isNull())).andReturn(null);
+        bundleContext.removeServiceListener((ServiceListener) anyObject());
+        replay(bundleContext);
+        ServiceAuthenticationHttpContext ctx = createContext(bundleContext, "service-any");
+        ctx.close();
+    }
+
+    private String printBooleanList(boolean[] authValues) {
+        StringBuffer ret = new StringBuffer();
+        for (boolean authValue : authValues) {
+            ret.append(authValue).append("::");
+        }
+        return ret.toString().substring(0,ret.length()-2);
+    }
+
+    private ServiceReference[] createServiceReferences(BundleContext bundleContext, boolean ... authResults) throws InvalidSyntaxException {
+        ArrayList<ServiceReference> ret = new ArrayList<ServiceReference>();
+        for (boolean authResult : authResults) {
+            ServiceReference ref = createMock(ServiceReference.class);
+            Authenticator auth = new TestAuthenticator(authResult);
+            expect(bundleContext.getService(eq(ref))).andReturn(auth);
+            replay(ref);
+            ret.add(ref);
+        }
+        return ret.toArray(new ServiceReference[0]);
+    }
+
+    private HttpServletResponse prepareResponse() {
+        return createMock(HttpServletResponse.class);
+    }
+
+    private ServiceAuthenticationHttpContext createContext(BundleContext bundleContext, String authMode) {
+        return new ServiceAuthenticationHttpContext(bundleContext,authMode);
+    }
+
+    // ===================================================================================
+
+    public static class TestAuthenticator implements Authenticator {
+
+        boolean pass;
+
+        TestAuthenticator(boolean pass) {
+            this.pass = pass;
+        }
+
+        @Override
+        public boolean authenticate(HttpServletRequest pRequest) {
+            return pass;
+        }
+
+    }
+}

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -23,9 +23,14 @@
     <author email="roland@jolokia.org">Roland Huß</author>
   </properties>
   <body>
-    <release version="1.4.1-SNAPSHOT" description="Release 1.4.1-SNAPSHOT">
+    <release version="1.5.0-SNAPSHOT" description="Release 1.5.0-SNAPSHOT">
       <action dev="rhuss" type="fix">
         Restrict allowed mime types to "text/plain" and "application/json" for the response.
+      </action>
+      <action dev="rysndgoulding" type="add" issue="358">
+        New authMode "service-any" and "service-all" to allow to lookup an
+        org.jolokia.osgi.security.Authenticator used for authentication. Note that this class has
+        been changed from an abstract base class to an interface for ease of customization.
       </action>
     </release>
     <release version="1.4.0" description="Release 1.4.0" date="2018-01-23">

--- a/src/docbkx/agents/osgi.xml
+++ b/src/docbkx/agents/osgi.xml
@@ -31,7 +31,7 @@
     <filename>jolokia-osgi.jar</filename> declaring all its package
     dependencies as imports in its Manifest and an all-in-one bundle
     <filename>jolokia-osgi-bundle.jar</filename> with minimal
-    dependecies. The pure bundle fits best with the OSGi philosophy and is
+    dependencies. The pure bundle fits best with the OSGi philosophy and is
     hence the recommended bundle. The all-in-one monster is good for a
     quick start since normally no additional bundles are required.
   </para>
@@ -379,10 +379,16 @@
          <td>org.jolokia.authMode</td>
          <td>basic</td>
          <td>
-           Can be either <literal>basic</literal> (the default) or <literal>jaas</literal>. If
+           Can be either <literal>basic</literal> (the default), <literal>jaas</literal>,
+           <literal>service-all</literal> or <literal>service-any</literal>. If
            <literal>jaas</literal> is used, the user and password given in the <literal>Authorization:</literal>
-           header are used for loging in via JAAS and, if successful, the return subject is used for all Jolokia operation.
-           This has only an effect, if user is set.
+           header are used for login in via JAAS and, if successful, the return subject is used for all Jolokia operation.
+           This has only an effect, if a user is set.
+           When no user is set and the <literal>authMode</literal> is either <literal>service-all</literal> or
+           <literal>service-any</literal> then a <litera>org.jolokia.osgi.security.Authenticator</litera> service is looked up in the
+           OSGi service registry. If more then one of such service is registered, <literal>service-all</literal> requires
+           that all authenticators succeed, for <literal>service-any</literal> it is sufficient that one authenticator
+           successfully authenticates.
          </td>
         </tr>
     </table>


### PR DESCRIPTION
Provides the capability to enable "authMode=service" in
org.jolokia.osgi.cfg.  This authentication mode provides the ability
to monitor the OSGi service registry for custom implementations of
the Authenticator interface, resulting in delegation of authentication
to third party implementations.  This is particularly useful for
integrating jolokia into an existing OSGi project.

If "authMode=service" is enabled, authentication only succeeds if
every implementation of Authenticator.authenticate(...) returns true.
If no implementations are provided, then authentication fails (i.e.,
the system defaults to fail-closed).

The initial idea was presented here:
https://github.com/rhuss/jolokia/pull/225

Signed-off-by: Ryan Goulding <ryandgoulding@gmail.com>