### PR TITLE
Also set secure processing feature for the PolicyRestrictor

### DIFF
--- a/agent/core/src/main/java/org/jolokia/restrictor/PolicyRestrictor.java
+++ b/agent/core/src/main/java/org/jolokia/restrictor/PolicyRestrictor.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -100,6 +101,13 @@ public class PolicyRestrictor implements Restrictor {
                 // Silently ignore as the feature might not be available for the
                 // given parser
             }
+        }
+        // Also set secure processing to true
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException exp) {
+            // Silently ignore as the feature might not be available for the
+            // given parser
         }
         return factory.newDocumentBuilder().parse(pInput);
     }


### PR DESCRIPTION
We should also set the secure processing feature for the PolicyRestrictor, to prevent various DoS style attacks.