### PR TITLE
Debian package: Allow installation with openjdk-8-jre and with headless JREs

### DIFF
--- a/agent/jvm/src/deb/control/control
+++ b/agent/jvm/src/deb/control/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: misc
 Priority: optional
 Architecture: all
-Depends: java-runtime
+Depends: java-runtime | java2-runtime | java-runtime-headless | java2-runtime-headless
 Maintainer: Roland Huss <roland@jolokia.org>
 Description: Jolokia is a JMX-HTTP bridge giving an alternative to JSR-160 connectors.
 Distribution: development


### PR DESCRIPTION
On Debian 9 (jessie), installing Jolokia when `openjdk-8-jre` (the default
JRE) is installed will pull `openjdk-11-jre` (or worst, `oracle-java6-jre` when
available). The reason being `openjdk-8-jre` has `Provides: java2-runtime`, but no
`Provides: java-runtime` (this is a bug on Debian's side that won't be
solved because Jessie is now LTS).

Also, Jolokia works with headless JRE. Adding those as alternative
depends.