### PR TITLE
Issue #446 : future proof some tests for newer openjdk distributions …

### DIFF
--- a/agent/jsr160/src/test/java/org/jolokia/jsr160/Jsr160RequestDispatcherTest.java
+++ b/agent/jsr160/src/test/java/org/jolokia/jsr160/Jsr160RequestDispatcherTest.java
@@ -171,9 +171,9 @@ public class Jsr160RequestDispatcherTest {
                 }
             } catch (IOException exp) {
                 // That's fine if allowed to pass
-                assertTrue(exp.getCause() instanceof CommunicationException);
+                assertTrue(exp.getCause() instanceof CommunicationException || exp.getCause() instanceof NamingException);
                 if (!(Boolean) testData[i+1]) {
-                    fail("Should not come that fat " + testData[i]);
+                    fail("Should not come that far " + testData[i]);
                 }
             }
         }


### PR DESCRIPTION
…(different exception for timeout of jsr160 connectons)

While looking at #446 : was not able to reproduce the exact issues seen in travis CI, but brute force tested other linux openjdk versions and found one future problem. 