### PR TITLE
Do not rely on whatever kubernetes context is current at the client (allow specifying context)

### DIFF
--- a/client/kubernetes/src/main/java/org/jolokia/kubernetes/client/KubernetesJmxConnector.java
+++ b/client/kubernetes/src/main/java/org/jolokia/kubernetes/client/KubernetesJmxConnector.java
@@ -67,6 +67,13 @@ public class KubernetesJmxConnector extends JolokiaJmxConnector {
     }
     return client;
   }
+  
+  /**
+   * Manually reset any cached config. To be uses in case you have changed your kubeconfig
+   */
+  public static void resetKubernetesConfig() {
+	  apiClients.clear();
+  }
 
   /**
    * @return a connection if successful


### PR DESCRIPTION
Not specifying context can be highly confusing for users switching between different clusters. Allow connections to specify what context to use.