### PR TITLE
Ensure InputStreamReader is closed on method exit

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/security/DelegatingAuthenticator.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/security/DelegatingAuthenticator.java
@@ -119,7 +119,7 @@ public class DelegatingAuthenticator extends Authenticator {
 
         @Override
         public HttpPrincipal extract(URLConnection connection) throws IOException, ParseException {
-            final InputStreamReader isr = new InputStreamReader(connection.getInputStream())
+            final InputStreamReader isr = new InputStreamReader(connection.getInputStream());
             try {
                 Object payload = new JSONParser().parse(isr);
                 Stack<String> pathElements = EscapeUtil.extractElementsFromPath(path);

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/security/DelegatingAuthenticator.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/security/DelegatingAuthenticator.java
@@ -119,7 +119,8 @@ public class DelegatingAuthenticator extends Authenticator {
 
         @Override
         public HttpPrincipal extract(URLConnection connection) throws IOException, ParseException {
-            try (final InputStreamReader isr = new InputStreamReader(connection.getInputStream())) {
+            final InputStreamReader isr = new InputStreamReader(connection.getInputStream())
+            try {
                 Object payload = new JSONParser().parse(isr);
                 Stack<String> pathElements = EscapeUtil.extractElementsFromPath(path);
                 Object result = payload;
@@ -131,6 +132,8 @@ public class DelegatingAuthenticator extends Authenticator {
                     result = extractValue(result, key);
                 }
                 return new HttpPrincipal(result.toString(), realm);
+            } finally {
+                isr.close();
             }
         }
 


### PR DESCRIPTION
Uses try-with-resources to ensure the InputStreamReader is closed upon exiting the try-block.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>