### PR TITLE
Fix possible integer overflow in OperationChecking.java

### DIFF
--- a/it/core/src/main/java/org/jolokia/it/OperationChecking.java
+++ b/it/core/src/main/java/org/jolokia/it/OperationChecking.java
@@ -1,7 +1,7 @@
 package org.jolokia.it;
 
 /*
- * Copyright 2009-2013 Roland Huss
+ * Copyright 2009-2021 Roland Huss
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ public class OperationChecking implements OperationCheckingMBean,MBeanRegistrati
 
     public int sleep(int seconds) throws InterruptedException {
         synchronized(this) {
-            this.wait(seconds * 1000);
+            this.wait(seconds * 1000L);
         }
         return seconds;
     }


### PR DESCRIPTION
By using a long constant instead of an int, seconds will be
type-upgraded to a long as well.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>