### PR TITLE
487: Interpret null signature as signature without parameters (Support Visual VM)

### DIFF
--- a/client/jmx-adapter/src/main/java/org/jolokia/client/jmxadapter/RemoteJmxAdapter.java
+++ b/client/jmx-adapter/src/main/java/org/jolokia/client/jmxadapter/RemoteJmxAdapter.java
@@ -439,7 +439,7 @@ public class RemoteJmxAdapter implements MBeanServerConnection {
   public Object invoke(ObjectName name, String operationName, Object[] params, String[] signature)
       throws InstanceNotFoundException, MBeanException, IOException {
     //jvisualvm may send null for no parameters
-    if (params == null && signature.length == 0) {
+    if (params == null && (signature == null || signature.length == 0)) {
       params = new Object[0];
     }
     try {
@@ -457,11 +457,13 @@ public class RemoteJmxAdapter implements MBeanServerConnection {
 
   private String makeSignature(String[] signature) {
     StringBuilder builder = new StringBuilder("(");
-    for (int i = 0; i < signature.length; i++) {
-      if (i > 0) {
-        builder.append(',');
+    if(signature != null) {
+      for (int i = 0; i < signature.length; i++) {
+        if (i > 0) {
+          builder.append(',');
+        }
+        builder.append(signature[i]);
       }
-      builder.append(signature[i]);
     }
     builder.append(')');
     return builder.toString();

--- a/client/jmx-adapter/src/test/java/org/jolokia/client/jmxadapter/JmxBridgeTest.java
+++ b/client/jmx-adapter/src/test/java/org/jolokia/client/jmxadapter/JmxBridgeTest.java
@@ -254,13 +254,13 @@ public class JmxBridgeTest {
         {
             RemoteJmxAdapter.getObjectName("java.lang:type=Threading"),
             "findDeadlockedThreads",
-            new Object[0]
+            null
         },
-        {RemoteJmxAdapter.getObjectName("java.lang:type=Memory"), "gc", new Object[0]},
+        {RemoteJmxAdapter.getObjectName("java.lang:type=Memory"), "gc", null},
         {
             RemoteJmxAdapter.getObjectName("com.sun.management:type=DiagnosticCommand"),
             "vmCommandLine",
-            new Object[0]
+            null
         },
         {
             RemoteJmxAdapter.getObjectName("com.sun.management:type=HotSpotDiagnostic"),
@@ -510,11 +510,8 @@ public class JmxBridgeTest {
     try {
       for (MBeanOperationInfo operationInfo : this.adapter.getMBeanInfo(name).getOperations()) {
         if (operationInfo.getName().equals(operation)
-            && operationInfo.getSignature().length == arguments.length) {
-          String[] signature = new String[operationInfo.getSignature().length];
-          for (int i = 0; i < signature.length; i++) {
-            signature[i] = operationInfo.getSignature()[i].getType();
-          }
+            && argumentCountIsCompatible(arguments, operationInfo.getSignature().length)) {
+          String[] signature = createSignature(operationInfo);
           Assert.assertEquals(
               this.adapter.invoke(name, operation, arguments, signature),
               nativeServer.invoke(name, operation, arguments, signature));
@@ -526,6 +523,21 @@ public class JmxBridgeTest {
               .getProperty("java.runtime.version") + " skipping");
     }
   }
+
+private String[] createSignature(MBeanOperationInfo operationInfo) {
+	if(operationInfo.getSignature().length == 0) {
+		return null;//simulate JVisualVM by returning null instead of an empty array
+	}
+	String[] signature = new String[operationInfo.getSignature().length];
+	  for (int i = 0; i < signature.length; i++) {
+	    signature[i] = operationInfo.getSignature()[i].getType();
+	  }
+	return signature;
+}
+
+private boolean argumentCountIsCompatible(Object[] arguments, int argumentCount) {
+	return (arguments == null && argumentCount == 0) || argumentCount == arguments.length;
+}
 
   @Test(dataProvider = "allNames")
   public void testInstances(ObjectName name) throws InstanceNotFoundException, IOException {

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -23,6 +23,12 @@
     <author email="roland@jolokia.org">Roland Huß</author>
   </properties>
   <body>
+    <release version="1.7.2" description="Release 1.7.2" >
+      <action dev="skarsaune" type="fix" issue="487">
+        Support calling invoke with null as arguments and signature for operations with no arguments over JMX connection.
+        Java Visual VM does this.
+      </action>
+    </release>
     <release version="1.7.1" description="Release 1.7.1" date="2021-09-19">
       <action dev="grgrzybek" type="fix" issue="477">
         Removed local system dependencies in jvm-agent's pom.xml that accidentally slipped in


### PR DESCRIPTION
# Changes

- :bug: Tolerate Visual VM calling operations without parameters
/kind <kind>

/kind bug

Fixes #487

**Release Note**

```release-note

Fixes bug that made calling methods with no parameters fail with Visual VM over Jolokia connections.
```