### PR TITLE
Fix typo in default agent properties

### DIFF
--- a/agent/jvm/src/main/resources/default-jolokia-agent.properties
+++ b/agent/jvm/src/main/resources/default-jolokia-agent.properties
@@ -48,7 +48,7 @@ backlog=10
 # user=bragg
 # password=secret
 
-# How many entroes to keep in the history
+# How many entries to keep in the history
 historyMaxEntries=10
 
 # Switch on debugging


### PR DESCRIPTION
# Changes

- :broom: A typo in a comment line.

/kind documentation
