### PR TITLE
Fix error for invalid executor in config

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServerConfig.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServerConfig.java
@@ -558,8 +558,8 @@ public class JolokiaServerConfig {
         if (!"single".equalsIgnoreCase(executor) &&
                 !"fixed".equalsIgnoreCase(executor) &&
                 !"cached".equalsIgnoreCase(executor)) {
-            throw new IllegalArgumentException("Executor model can be '" + executor +
-                                               "' but most be either 'single', 'fixed' or 'cached'");
+            throw new IllegalArgumentException("Invalid executor model: '" + executor +
+                                               "'. Must be either 'single', 'fixed' or 'cached'");
         }
     }
 


### PR DESCRIPTION
# Changes

- :broom: Update error message: fix typo and make it look more like the other messages in the same file.

/kind cleanup
