### PR TITLE
Issue-504: Fix one type mapping in flight recorder, allow clients to fix other cases

### DIFF
--- a/client/jmx-adapter/src/main/java/org/jolokia/client/jmxadapter/ToOpenTypeConverter.java
+++ b/client/jmx-adapter/src/main/java/org/jolokia/client/jmxadapter/ToOpenTypeConverter.java
@@ -201,6 +201,9 @@ public class ToOpenTypeConverter {
         return new CompositeType("complex", "complex", keys, keys, types);
       }
     }
+    if( rawValue == null ) {
+      return VOID;
+    }
     // should probably never happen, to signify type could not be found
     throw new InvalidOpenTypeException("Unable to figure out type for " + rawValue);
   }
@@ -325,10 +328,20 @@ public class ToOpenTypeConverter {
     }
     //may be null on Java 10
     cacheType(STRING, "jdk.management.jfr:type=FlightRecorder.EventTypes.item.description");
+    cacheType(STRING, "jdk.management.jfr:type=FlightRecorder.getRecordingOptions.destination");
     return TYPE_SPECIFICATIONS.get(name);
   }
 
-  static void cacheType(OpenType<?> type, String... names) {
+  /**
+   * Specify type to use for an attribute, operation or an attribute within the response.
+   * Syntax
+   * <pre>
+   *   cacheType(TYPE, "ObjectName.Operation/Attribute.item(if array).attribute.innerattribute")
+   * </pre>
+   * @param type type to apply for reverse engineering
+   * @param names One or more items to type according to syntax given above
+   */
+  public static void cacheType(OpenType<?> type, String... names) {
     for (String name : names) {
       TYPE_SPECIFICATIONS.put(name, type);
     }
@@ -343,7 +356,12 @@ public class ToOpenTypeConverter {
     return type;
   }
 
-  static OpenType<?> introspectComplexTypeFrom(Class<?> klass) throws OpenDataException {
+  /**
+   * @param klass The Java type
+   * @return OpenType deducted from Java type by reflection
+   * @throws OpenDataException
+   */
+  public static OpenType<?> introspectComplexTypeFrom(Class<?> klass) throws OpenDataException {
     if (CompositeData.class.equals(klass) || TabularData.class.equals(klass)) {
       //do not attempt to read from these classes, will have to be created from the "real" class runtime
       return null;

--- a/client/jmx-adapter/src/test/java/org/jolokia/client/jmxadapter/JmxBridgeTest.java
+++ b/client/jmx-adapter/src/test/java/org/jolokia/client/jmxadapter/JmxBridgeTest.java
@@ -36,6 +36,7 @@ import javax.management.MBeanInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.Notification;
 import javax.management.NotificationListener;
@@ -45,7 +46,10 @@ import javax.management.Query;
 import javax.management.QueryExp;
 import javax.management.ReflectionException;
 import javax.management.RuntimeMBeanException;
+import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
 import javax.management.remote.JMXConnectionNotification;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
@@ -299,6 +303,26 @@ public class JmxBridgeTest {
             new Object[]{new long[]{1L}, true, true},
             new String[]{"[J", "boolean", "boolean"}}
     };
+  }
+
+  @Test
+  public void testRecodringSettings()
+      throws MalformedObjectNameException, IOException, MBeanException, InstanceNotFoundException {
+    final ObjectName objectName = new ObjectName("jdk.management.jfr:type=FlightRecorder");
+    try {
+      final MBeanInfo mBeanInfo = this.adapter.getMBeanInfo(objectName);
+    } catch (InstanceNotFoundException e) {
+      //skip test for older JVMs
+      return;
+    }
+    final Object newRecording = this.adapter.invoke(objectName, "newRecording", new Object[0], new String[0]);
+
+    final Object recordingOptions = this.adapter
+        .invoke(objectName, "getRecordingOptions", new Object[]{newRecording},
+            new String[]{"long"});
+    Assert.assertTrue(recordingOptions instanceof CompositeDataSupport);
+    OpenType<?> descriptionType=((CompositeDataSupport)recordingOptions).getCompositeType().getType("destination");
+    Assert.assertEquals(descriptionType, SimpleType.STRING);
   }
 
   @DataProvider


### PR DESCRIPTION
# Changes

- :bug: Handle runtime exception jdk.management.jfr:type=FlightRecorder.getRecordingOptions
- :gift: Allow handling other such cases without waiting for Jolokia release

/kind bug
/kind enhancement



Fixes #504 

**Release Note**

```release-note
Allow specifying types for reverse engineering composite types returned from JSR-160 adapter.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
