### PR TITLE
#515: Remove awaitility and wiremock dependencies

### DIFF
--- a/client/jmx-adapter/pom.xml
+++ b/client/jmx-adapter/pom.xml
@@ -38,28 +38,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>1.58</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jetty</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.jayway.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>1.7.0</version>
-            <scope>test</scope>
-        </dependency>
         <!-- note jolokia-jvm dependency must come before jolokia-core
         as it is shaded and the combination does not work
         hence unconventionally listing test deps first -->


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- 🗑️ : Remove test dependencies that are not currently in use

/kind cleanup

Fixes #515

