### PR TITLE
Improve proxy denylist

### DIFF
--- a/agent/jsr160/src/main/java/org/jolokia/jsr160/Jsr160RequestDispatcher.java
+++ b/agent/jsr160/src/main/java/org/jolokia/jsr160/Jsr160RequestDispatcher.java
@@ -60,6 +60,7 @@ public class Jsr160RequestDispatcher implements RequestDispatcher {
     public static final String ALLOWED_TARGETS_ENV = "JOLOKIA_JSR160_PROXY_ALLOWED_TARGETS";
 
     // White and blacklist for patterns to match the JMX Service URL against
+    // Pattern matching is done case insensitive
     private final Set<String> whiteList;
     private final Set<String> blackList;
 
@@ -195,7 +196,7 @@ public class Jsr160RequestDispatcher implements RequestDispatcher {
 
     private boolean checkPattern(Set<String> patterns, String urlS, boolean isPositive) {
         for (String pattern : patterns) {
-            if (Pattern.compile(pattern).matcher(urlS).matches()) {
+            if (Pattern.compile(pattern, Pattern.CASE_INSENSITIVE).matcher(urlS).matches()) {
                 return isPositive;
             }
         }

--- a/src/docbkx/proxy.xml
+++ b/src/docbkx/proxy.xml
@@ -75,7 +75,7 @@
       Additionally you can configured a white list with patterns for all allowed JMX service URL in a Jolokia Request.
       This white list is a plain text file which contains <ulink
     url="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Patterns</ulink> line by line. Lines starting with <literal>#</literal> are ignored.
-      This file can be configured in various ways:
+      Pattern matching is performed case insensitive. This file can be configured in various ways:
     </para>
     <itemizedlist>
       <listitem>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -231,6 +231,7 @@
           Also, you can now configure a whitelist with allowed patterns for the JMX service URL used as
           the target URL of the proxy.
           These patterns are supposed to be contained in a plain text file, line by line.
+          Pattern matching is performed case insensitive.
           This file then can be referenced by a system property, an env variable or directly configured in
           <code>web.xml</code>
           in the war file.


### PR DESCRIPTION
### Changes

Jolokia attempts to prevent LDAP based JNDI injection attacks by applying a default denylist to JMX service URLs that are supplied in proxy-mode. However, the pattern matching that is done with this list is case sensitive. This allows for an easy bypass of the protection. The following JMX service URL passes the filter and causes an outbound LDAP connection:

```
service:jmx:Rmi:///jndi/ldap://bypassed/ups
```

I hope you don't mind the public disclosure, but I estimate the impact of this issue quite low.

/kind enhancement

### Release Note

```release-note
The white and blacklist that user supplied JMX service URLs are matched against when running Jolokia in proxy mode are now treated case insensitive. This could cause different behavior for already existing configurations. If you use Jolokia in proxy mode and rely on specific white or blacklist settings, you should review your configuration.
```