### PR TITLE
Correct fileSimplifier test by making it less strict and more semantic

### DIFF
--- a/service/serializer/src/test/java/org/jolokia/service/serializer/json/SimplifiersTest.java
+++ b/service/serializer/src/test/java/org/jolokia/service/serializer/json/SimplifiersTest.java
@@ -79,7 +79,7 @@ public class SimplifiersTest {
     public void fileSimplifier() throws AttributeNotFoundException {
         File file = new File("/etc/os-release");
         Object result = fileSimplifier.extractObject(converter, file, new LinkedList<>(), true);
-        assertTrue(((JSONObject) result).toJSONString().contains("{\"name\":\"os-release\""));
+        assertEquals(((JSONObject) result).get("name"), "os-release");
     }
 
     @Test


### PR DESCRIPTION
## Summary  
This PR updates the `fileSimplifier` test in `SimplifiersTest` to assert directly on JSON fields instead of relying on serialized string matching.  

Previously, the test used a strict substring comparison against the result of `JSONObject.toJSONString()`. This approach assumed a fixed key ordering and formatting in the JSON output, which is not guaranteed. When running with tools like NonDex that randomize iteration order, the test could fail nondeterministically even though the actual behavior was correct.  

---

## Changes made  
- Replaced substring comparison on `toJSONString()` with a direct field assertion:  

```java
assertEquals(((JSONObject) result).get("name"), "os-release");
```
This change ensures the test verifies the semantic content of the JSON object rather than its serialized formatting.

---
## Rationale
- Prevents nondeterministic failures: JSON object field order is not guaranteed, so relying on raw string output could cause false negatives.
- Improves correctness: The test now checks that the "name" field has the expected value, which is the actual property under test.
- Enhances stability and portability: The test suite no longer depends on serializer-specific behavior or JVM-dependent hash ordering.