### PR TITLE
Added support/spring7 module

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -377,6 +377,11 @@
         <artifactId>jolokia-support-spring</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.jolokia</groupId>
+        <artifactId>jolokia-support-spring7</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/examples/spring-boot4-actuator/pom.xml
+++ b/examples/spring-boot4-actuator/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2013 Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jolokia-example-spring-boot4-actuator</artifactId>
+  <version>2.4.3-SNAPSHOT</version>
+
+  <name>jolokia-example-spring-boot4-actuator</name>
+  <description>Jolokia :: Support :: Spring Boot Actuator :: Sample</description>
+
+  <parent>
+    <groupId>org.jolokia</groupId>
+    <artifactId>jolokia-parent</artifactId>
+    <version>2.4.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <url>https://jolokia.org/</url>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.tools.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.org.springframework7}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${version.org.springframework.boot4}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <!-- Jolokia own artifacts -->
+
+    <dependency>
+      <!-- This one is enough -->
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-support-spring7</artifactId>
+    </dependency>
+
+    <!-- Other dependencies -->
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/examples/spring-boot4-actuator/src/main/java/org/jolokia/support/spring/boot4/sample/Application.java
+++ b/examples/spring-boot4-actuator/src/main/java/org/jolokia/support/spring/boot4/sample/Application.java
@@ -1,0 +1,85 @@
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.boot4.sample;
+
+import javax.management.ObjectName;
+
+import org.jolokia.server.core.service.api.Restrictor;
+import org.jolokia.server.core.util.HttpMethod;
+import org.jolokia.server.core.util.RequestType;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class);
+    }
+
+    /**
+     * This {@link Restrictor} will be available in Spring's context and used later in
+     * {@link org.jolokia.server.core.http.AgentServlet}.
+     * @return
+     */
+    @Bean
+    public Restrictor customRestrictor() {
+        return new Restrictor() {
+            @Override
+            public boolean isHttpMethodAllowed(HttpMethod pMethod) {
+                return true;
+            }
+
+            @Override
+            public boolean isTypeAllowed(RequestType pType) {
+                return true;
+            }
+
+            @Override
+            public boolean isAttributeReadAllowed(ObjectName pName, String pAttribute) {
+                return true;
+            }
+
+            @Override
+            public boolean isAttributeWriteAllowed(ObjectName pName, String pAttribute) {
+                return true;
+            }
+
+            @Override
+            public boolean isOperationAllowed(ObjectName pName, String pOperation) {
+                return true;
+            }
+
+            @Override
+            public boolean isRemoteAccessAllowed(String... pHostOrAddress) {
+                return true;
+            }
+
+            @Override
+            public boolean isOriginAllowed(String pOrigin, boolean pOnlyWhenStrictCheckingIsEnabled) {
+                return true;
+            }
+
+            @Override
+            public boolean isObjectNameHidden(ObjectName name) {
+                return false;
+            }
+        };
+    }
+
+}

--- a/examples/spring-boot4-actuator/src/main/resources/application.properties
+++ b/examples/spring-boot4-actuator/src/main/resources/application.properties
@@ -1,0 +1,24 @@
+#
+# Copyright 2009-2023 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server.port = 8181
+
+management.endpoint.jolokia.config.debug = true
+management.endpoint.jolokia.config.agentDescription = Jolokia Spring Boot Actuator agent
+
+management.endpoints.web.exposure.include = health, jolokia
+
+management.endpoint.threaddump.enabled = false

--- a/examples/spring-boot4-actuator/src/main/resources/log4j2.properties
+++ b/examples/spring-boot4-actuator/src/main/resources/log4j2.properties
@@ -1,0 +1,30 @@
+#
+# Copyright 2009-2023 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+status = INFO
+verbose = false
+dest = out
+
+appender.stdout.type = Console
+appender.stdout.name = stdout
+appender.stdout.layout.type = PatternLayout
+appender.stdout.layout.pattern = %d{HH:mm:ss} %level {%thread} [%C] (%F:%L) : %msg%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = stdout
+
+logger.jolokia.name = org.jolokia
+logger.jolokia.level = debug

--- a/examples/spring-boot4/pom.xml
+++ b/examples/spring-boot4/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2013 Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jolokia-example-spring-boot4</artifactId>
+  <version>2.4.3-SNAPSHOT</version>
+
+  <name>jolokia-example-spring-boot4</name>
+  <description>Jolokia :: Support :: Spring Boot :: Sample</description>
+
+  <parent>
+    <groupId>org.jolokia</groupId>
+    <artifactId>jolokia-parent</artifactId>
+    <version>2.4.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <url>https://jolokia.org/</url>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.tools.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.org.springframework7}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${version.org.springframework.boot4}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <!-- Jolokia own artifacts -->
+
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-support-spring7</artifactId>
+    </dependency>
+
+    <!-- Other dependencies -->
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/examples/spring-boot4/src/main/java/org/jolokia/support/spring/boot4/sample/AppConfig.java
+++ b/examples/spring-boot4/src/main/java/org/jolokia/support/spring/boot4/sample/AppConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2009-2023 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.boot4.sample;
+
+import java.util.Map;
+
+import org.jolokia.server.core.config.ConfigKey;
+import org.jolokia.server.core.http.AgentServlet;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ServletRegistrationBean<AgentServlet> jolokia() {
+        ServletRegistrationBean<AgentServlet> jolokiaServlet = new ServletRegistrationBean<>(new AgentServlet(), "/jolokia/*");
+        jolokiaServlet.setLoadOnStartup(0);
+        jolokiaServlet.setAsyncSupported(true);
+        jolokiaServlet.setInitParameters(Map.of(ConfigKey.DEBUG.getKeyValue(), "true"));
+        jolokiaServlet.setInitParameters(Map.of(ConfigKey.AGENT_DESCRIPTION.getKeyValue(), "Spring Servlet Jolokia Agent"));
+        return jolokiaServlet;
+    }
+
+}

--- a/examples/spring-boot4/src/main/java/org/jolokia/support/spring/boot4/sample/Application.java
+++ b/examples/spring-boot4/src/main/java/org/jolokia/support/spring/boot4/sample/Application.java
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.boot4.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class);
+    }
+
+}

--- a/examples/spring-boot4/src/main/resources/application.properties
+++ b/examples/spring-boot4/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2009-2023 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server.port = 8181

--- a/examples/spring-boot4/src/main/resources/log4j2.properties
+++ b/examples/spring-boot4/src/main/resources/log4j2.properties
@@ -1,0 +1,30 @@
+#
+# Copyright 2009-2023 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+status = INFO
+verbose = false
+dest = out
+
+appender.stdout.type = Console
+appender.stdout.name = stdout
+appender.stdout.layout.type = PatternLayout
+appender.stdout.layout.pattern = %d{HH:mm:ss} %level {%thread} [%C] (%F:%L) : %msg%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = stdout
+
+logger.jolokia.name = org.jolokia
+logger.jolokia.level = debug

--- a/examples/spring7/pom.xml
+++ b/examples/spring7/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2013 Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jolokia-example-spring7</artifactId>
+  <version>2.4.3-SNAPSHOT</version>
+
+  <name>jolokia-example-spring7</name>
+  <description>Jolokia :: Support :: Spring :: Sample</description>
+
+  <parent>
+    <groupId>org.jolokia</groupId>
+    <artifactId>jolokia-parent</artifactId>
+    <version>2.4.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <url>https://jolokia.org/</url>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.tools.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.org.springframework7}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <!-- Jolokia own artifacts -->
+
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-service-jmx</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-support-jmx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-support-spring7</artifactId>
+    </dependency>
+
+    <!-- Other dependencies -->
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${version.org.apache.logging.log4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${version.org.apache.logging.log4j}</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/examples/spring7/src/main/java/org/jolokia/support/spring7/sample/Application.java
+++ b/examples/spring7/src/main/java/org/jolokia/support/spring7/sample/Application.java
@@ -1,0 +1,32 @@
+package org.jolokia.support.spring7.sample;
+/*
+ *
+ * Copyright 2016 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @author roland
+ * @since 08/08/16
+ */
+public class Application {
+
+    public static void main(String[] args) throws InterruptedException {
+        ApplicationContext ctx = new ClassPathXmlApplicationContext("/applicationContext.xml");
+        Thread.sleep(3600 * 1000);
+    }
+}

--- a/examples/spring7/src/main/resources/applicationContext.xml
+++ b/examples/spring7/src/main/resources/applicationContext.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2023  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:jolokia="http://www.jolokia.org/jolokia-spring/schema/config"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+           http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+           http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+           http://www.jolokia.org/jolokia-spring/schema/config https://www.jolokia.org/jolokia-config.xsd">
+
+  <context:property-placeholder system-properties-mode="ENVIRONMENT"/>
+
+  <context:mbean-export server="jolokiaMBeanServer"/>
+
+  <jolokia:mbean-server id="jolokiaMBeanServer"/>
+
+  <util:map id="configuration">
+    <entry key="jmx.jolokiaPort" value="8778"/>
+  </util:map>
+
+  <jolokia:agent id="jolokia" lookupConfig="true" lookupServices="true" systemPropertiesMode="override"
+                 exposeApplicationContext="true">
+    <jolokia:config autoStart="true"
+                    port="#{configuration['jmx.jolokiaPort']}"
+                    host="127.0.0.1"/>
+    <jolokia:log type="slf4j"/>
+  </jolokia:agent>
+
+</beans>

--- a/examples/spring7/src/main/resources/log4j2.properties
+++ b/examples/spring7/src/main/resources/log4j2.properties
@@ -1,0 +1,30 @@
+#
+# Copyright 2009-2023 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+status = INFO
+verbose = false
+dest = out
+
+appender.stdout.type = Console
+appender.stdout.name = stdout
+appender.stdout.layout.type = PatternLayout
+appender.stdout.layout.pattern = %d{HH:mm:ss} %level {%thread} [%C] (%F:%L) : %msg%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = stdout
+
+logger.jolokia.name = org.jolokia
+logger.jolokia.level = debug

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,16 @@
 
     <module>support/jmx</module>
     <module>support/spring</module>
+    <module>support/spring7</module>
 
     <module>examples/osgi-restrictor</module>
     <module>examples/client-javascript-test-app</module>
     <module>examples/spring</module>
     <module>examples/spring-boot</module>
     <module>examples/spring-boot-actuator</module>
+    <module>examples/spring7</module>
+    <module>examples/spring-boot4</module>
+    <module>examples/spring-boot4-actuator</module>
   </modules>
 
   <build>
@@ -830,6 +834,11 @@
         <artifactId>jolokia-support-spring</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.jolokia</groupId>
+        <artifactId>jolokia-support-spring7</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- JakartaEE dependencies -->
 
@@ -1209,6 +1218,7 @@
     <!-- Versions of test-related dependencies -->
 
     <version.com.fasterxml.jackson>2.20.1</version.com.fasterxml.jackson>
+    <version.tools.jackson>3.0.2</version.tools.jackson>
     <version.jakarta.annotation-api>3.0.0</version.jakarta.annotation-api>
     <version.jakarta.authentication-api>3.1.0</version.jakarta.authentication-api>
     <version.net.bytebuddy>1.18.1</version.net.bytebuddy>
@@ -1252,6 +1262,8 @@
     <!-- Spring Framework and Spring Boot should be aligned -->
     <version.org.springframework>6.2.13</version.org.springframework>
     <version.org.springframework.boot>3.5.7</version.org.springframework.boot>
+    <version.org.springframework7>7.0.1</version.org.springframework7>
+    <version.org.springframework.boot4>4.0.0</version.org.springframework.boot4>
   </properties>
 
   <profiles>

--- a/support/spring7/pom.xml
+++ b/support/spring7/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2013 Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jolokia-support-spring7</artifactId>
+  <version>2.4.3-SNAPSHOT</version>
+
+  <name>jolokia-support-spring7</name>
+  <description>Jolokia :: Support :: Spring JVM Agent</description>
+
+  <parent>
+    <groupId>org.jolokia</groupId>
+    <artifactId>jolokia-parent</artifactId>
+    <version>2.4.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <url>https://jolokia.org/</url>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.tools.jackson}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <!-- Jolokia own artifacts -->
+
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-tools-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- With jolokia-agent-jvm we'll transitively get all required dependencies -->
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-agent-jvm</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-support-jmx</artifactId>
+    </dependency>
+
+    <!-- JakartaEE dependencies -->
+
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Other dependencies -->
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${version.org.springframework7}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${version.org.springframework7}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>${version.org.springframework.boot4}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+      <version>${version.org.springframework.boot4}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.org.springframework.boot4}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <version>${version.org.springframework.boot4}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${version.org.apache.logging.log4j}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/support/spring7/src/main/java/org/jolokia/support/spring/SpringJolokiaAgent.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/SpringJolokiaAgent.java
@@ -1,0 +1,224 @@
+package org.jolokia.support.spring;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jolokia.jvmagent.JolokiaServer;
+import org.jolokia.jvmagent.JolokiaServerConfig;
+import org.jolokia.server.core.config.SystemPropertyMode;
+import org.jolokia.server.core.service.api.JolokiaService;
+import org.jolokia.server.core.service.api.LogHandler;
+import org.jolokia.support.spring.backend.SpringRequestHandler;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.OrderComparator;
+
+/**
+ * A specialized JVM Agent for Spring environments
+ *
+ * @author roland
+ * @since 26.12.12
+ */
+public class SpringJolokiaAgent extends JolokiaServer implements ApplicationContextAware, InitializingBean, DisposableBean {
+
+    // Default configuration to use
+    private SpringJolokiaConfigHolder configHolder;
+
+    // Whether to lookup up other configurations in the context
+    private boolean lookupConfig = false;
+
+    // Whether to lookup Jolokia services from the spring context
+    private boolean lookupServices = false;
+
+    // Whether to expose the spring container itself via Jolokia
+    private boolean exposeApplicationContext = false;
+
+    // How to deal with system properties
+    private SystemPropertyMode systemPropertyMode;
+
+    // Remember the context for dynamic lookup of multiple configs
+    private ApplicationContext context;
+
+    // Log handler to use. If not given it is class looked up from the configuration
+    private SpringJolokiaLogHandlerHolder logHandlerHolder;
+
+    /**
+     * Callback used for initializing and optionally starting up the server
+     */
+    public void afterPropertiesSet() throws IOException {
+        Map<String, String> config = new HashMap<>();
+        if (systemPropertyMode == SystemPropertyMode.FALLBACK) {
+            config.putAll(lookupSystemProperties());
+        }
+        if (configHolder.getConfig() != null) {
+            config.putAll(configHolder.getConfig());
+        }
+
+        if (lookupConfig && context != null) {
+            config.putAll(lookupConfigurationFromContext());
+        }
+
+        if (systemPropertyMode == SystemPropertyMode.OVERRIDE) {
+            config.putAll(lookupSystemProperties());
+        }
+
+        // Spring specific config 'autoStart' gets removed herem
+        boolean autoStart = Boolean.parseBoolean(config.remove("autoStart"));
+
+        LogHandler logHandler = logHandlerHolder != null ? logHandlerHolder.getLogHandler() : null;
+        init(new JolokiaServerConfig(config, systemPropertyMode), logHandler);
+
+        if (exposeApplicationContext && context != null) {
+            addService(new SpringRequestHandler(context, 100));
+        }
+
+        if (lookupServices) {
+            lookupServices();
+        }
+
+        if (autoStart) {
+            start();
+        }
+    }
+
+    private void lookupServices() {
+        @SuppressWarnings("rawtypes")
+        Map<String,JolokiaService> services = context.getBeansOfType(JolokiaService.class);
+        for (JolokiaService<?> service : services.values()) {
+            addService(service);
+        }
+    }
+
+    private Map<String,String> lookupConfigurationFromContext() {
+        // Merge all configs in the context in the reverse order
+        Map<String,String> config = new HashMap<>();
+        Map<String, SpringJolokiaConfigHolder> configsMap = context.getBeansOfType(SpringJolokiaConfigHolder.class);
+        List<SpringJolokiaConfigHolder> configs = new ArrayList<>(configsMap.values());
+        configs.sort(new OrderComparator());
+        for (SpringJolokiaConfigHolder c : configs) {
+            if (c != this.configHolder) {
+                config.putAll(c.getConfig());
+            }
+        }
+        return config;
+    }
+
+    // Lookup system properties for all configurations possible
+    private Map<String, String> lookupSystemProperties() {
+        Map<String,String> ret = new HashMap<>();
+        Enumeration<?> propEnum = System.getProperties().propertyNames();
+        while (propEnum.hasMoreElements()) {
+            String prop = (String) propEnum.nextElement();
+            if (prop.startsWith("jolokia.")) {
+                String key = prop.substring("jolokia.".length());
+                ret.put(key,System.getProperty(prop));
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Stop the server
+     */
+    public void destroy() {
+        stop();
+    }
+
+    /**
+     * Set the configuration which is used, if no other configuration options are given
+     *
+     * @param pConfig configuration to use
+     */
+    public void setConfig(SpringJolokiaConfigHolder pConfig) {
+        configHolder = pConfig;
+    }
+
+    /**
+     * Set the log handler to use which is contained in the given holder
+     *
+     * @param pLogHandlerHolder holder of a log handler
+     */
+    public void setLogHandler(SpringJolokiaLogHandlerHolder pLogHandlerHolder) {
+        logHandlerHolder = pLogHandlerHolder;
+    }
+
+    /**
+     * Whether to lookup dynamically configs in the application context after creation
+     * of this bean. This especially useful if the server is automatically started in a different
+     * module and needs some extra customization. Used e.g for the spring plugin.
+     *
+     * @param pLookupConfig whether to lookup configuration dynamically. Default is false.
+     */
+    public void setLookupConfig(boolean pLookupConfig) {
+        lookupConfig = pLookupConfig;
+    }
+
+
+    /**
+     * Whether to expose the spring container itself for outside access via an own Spring reaml '@spring'
+     *
+     * @param pExposeApplicationContext true if the container itself should be exposed via Jolokia. Default is false
+     */
+    public void setExposeApplicationContext(boolean pExposeApplicationContext) {
+        exposeApplicationContext = pExposeApplicationContext;
+    }
+
+    /**
+     * Whether to lookup {@link JolokiaService}s from the application context. These are
+     * added according to their order to the set of the services present.
+     *
+     * @param pLookupServices whether to lookup jolokia services.
+     */
+    public void setLookupServices(boolean pLookupServices) {
+        lookupServices = pLookupServices;
+    }
+
+    /**
+     * Look for the appropriate configuration, merge multiple ones if given and start up
+     * the Jolokia Server if lookupConfig is true
+     *
+     * @param pContext spring context containing the bean definition
+     */
+    public void setApplicationContext(@SuppressWarnings("NullableProblems") ApplicationContext pContext)  {
+        context = pContext;
+    }
+
+    /**
+     * Set the system property mode for how to deal with configuration coming from system properties
+     */
+    public void setSystemPropertiesMode(String pMode) {
+        systemPropertyMode = SystemPropertyMode.fromMode(pMode);
+        if (systemPropertyMode == null) {
+            systemPropertyMode = SystemPropertyMode.NEVER;
+        }
+    }
+
+    /**
+     * Set spring context id, required because an ID can be given. Not used.
+     *
+     * @param pId id to set
+     */
+    public void setId(String pId) {}
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/SpringJolokiaConfigHolder.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/SpringJolokiaConfigHolder.java
@@ -1,0 +1,79 @@
+package org.jolokia.support.spring;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.core.Ordered;
+
+/**
+ * Configuration wrapper for a spring based configuration. It simply wraps a string-string map
+ * for values.
+ * The content of this object is used for building up a {@link org.jolokia.jvmagent.JolokiaServerConfig} for
+ * the server to start.
+ * <p>
+ * Multiple config objects can be present in a context, their precedence in decided
+ * upon the order: The higher the order, the more important the configuration is (overriding
+ * lower ordered configs). A server will pick them up, if its <code>lookupConfigs</code> property
+ * is set to true (by default it is "false").
+ * <p>
+ * You should use &lt;jolokia:config&gt; for defining configuration, either as standalone
+ * configuration (if using the "plugin") or as an embedded element to &lt;jolokia:server&gt;
+ *
+ * @author roland
+ * @since 28.12.12
+ */
+public class SpringJolokiaConfigHolder implements Ordered {
+
+    // configuration
+    private Map<String, String> config = new HashMap<>();
+
+    // order for multiple configurations available
+    private int order;
+
+    /**
+     * Get tge configuration as a free-form map
+     * @return config map
+     */
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    /**
+     * Set the configuration values
+     *
+     * @param pConfig configuration to set
+     */
+    public void setConfig(Map<String, String> pConfig) {
+        config = pConfig;
+    }
+
+    /**
+     * Set the order or priority of this configuration. Higher orders mean higher priority.
+     *
+     * @param pOrder order to set
+     */
+    public void setOrder(int pOrder) {
+        order = pOrder;
+    }
+
+    /** {@inheritDoc} */
+    public int getOrder() {
+        return order;
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/SpringJolokiaLogHandlerHolder.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/SpringJolokiaLogHandlerHolder.java
@@ -1,0 +1,100 @@
+package org.jolokia.support.spring;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.jolokia.server.core.service.api.LogHandler;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.StringUtils;
+
+/**
+ * A holder for logging configuration for the spring agent
+ *
+ * @author roland
+ * @since 17.10.13
+ */
+public class SpringJolokiaLogHandlerHolder implements InitializingBean {
+
+    // the final log handler to use
+    private LogHandler logHandler;
+
+    // log handler type
+    private String type;
+
+    // logging category
+    private String category;
+
+    /** {@inheritDoc} */
+    public void afterPropertiesSet() {
+        if (logHandler == null) {
+            if (StringUtils.hasLength(type)) {
+                LogHandlerType lht = LogHandlerType.byType(type);
+                if (lht == null) {
+                    throw new IllegalArgumentException("No loghandler with type " + type + " known");
+                }
+                logHandler = lht.createLogHandler(StringUtils.hasLength(category) ? category : null);
+            } else {
+                throw new IllegalArgumentException("Neither 'log-ref' nor 'type' given. Please provide one of them");
+            }
+        }
+    }
+
+    public void setLogHandler(LogHandler pLogHandler) {
+        logHandler = pLogHandler;
+    }
+
+    public void setType(String pType) {
+        type = pType;
+    }
+
+    public void setCategory(String pCategory) {
+        category = pCategory;
+    }
+
+    public LogHandler getLogHandler() {
+        return logHandler;
+    }
+
+    // ==============================================================================
+
+    // Enumeration for the various log handler which are looked up by reflection in order
+    // to avoid hard dependencies on all those logging frameworks
+    enum LogHandlerType {
+        STDOUT("stdout","org.jolokia.server.core.service.impl.StdoutLogHandler"),
+        QUIET("quiet","org.jolokia.server.core.service.impl.QuietLogHandler"),
+        JUL("jul","org.jolokia.server.core.service.impl.JulLogHandler"),
+        LOG4J2("log4j2","org.jolokia.support.spring.log.Log4j2LogHandler"),
+        SLF4J("slf4j","org.jolokia.support.spring.log.Slf4jLogHandler"),
+        COMMONS("commons","org.jolokia.support.spring.log.CommonsLogHandler");
+
+        private final String className;
+        private final String type; // NOPMD
+
+        LogHandlerType(String pType, String pClassName) {
+            this.className = pClassName;
+            this.type = pType;
+        }
+
+        static LogHandlerType byType(String name) {
+            for (LogHandlerType t : values()) {
+                if (t.type.equals(name)) {
+                    return t;
+                }
+            }
+            return null;
+        }
+
+        LogHandler createLogHandler(String category) {
+            try {
+                @SuppressWarnings("unchecked")
+                Class<LogHandler> clazz = (Class<LogHandler>) this.getClass().getClassLoader().loadClass(className);
+                Constructor<LogHandler> ctr = clazz.getConstructor(String.class);
+                return ctr.newInstance(category);
+            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+                     InvocationTargetException | ClassNotFoundException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/SpringJolokiaMBeanServerFactory.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/SpringJolokiaMBeanServerFactory.java
@@ -1,0 +1,52 @@
+package org.jolokia.support.spring;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import javax.management.MBeanServer;
+
+import org.jolokia.support.jmx.JolokiaMBeanServerUtil;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Simple Factory bean for looking up the jolokia MBeanServer
+ *
+ * @author roland
+ * @since 11.02.13
+ */
+public class SpringJolokiaMBeanServerFactory implements FactoryBean<MBeanServer> {
+
+    /**
+     * Get the Jolokia MBeanServer. This call is delegated to the corresponding
+     * static utility method and will register a new MBeanServer if not already
+     * present
+     *
+     * @return the Jolokia MBeanServer
+     */
+    public MBeanServer getObject() {
+        return JolokiaMBeanServerUtil.getJolokiaMBeanServer();
+    }
+
+    /** {@inheritDoc} */
+    public Class<?> getObjectType() {
+        return MBeanServer.class;
+    }
+
+    /** {@inheritDoc} */
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaProperties.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaProperties.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2009-2023 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.actuator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "management.endpoint.jolokia")
+public class JolokiaProperties {
+
+    /**
+     * Jolokia configuration map. See {@link org.jolokia.server.core.config.ConfigKey}
+     */
+    private final Map<String, String> config = new HashMap<>();
+
+    public Map<String, String> getConfig() {
+        return this.config;
+    }
+
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaServletAutoConfiguration.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaServletAutoConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2009-2023 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.actuator;
+
+import org.jolokia.server.core.http.AgentServlet;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.expose.EndpointExposure;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.ManagementContextType;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.webmvc.autoconfigure.DispatcherServletPath;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * This autoconfiguration is for "management context" and provides a {@link AgentServlet Jolokia Servlet} registration
+ * {@link Bean} that simply calls {@link jakarta.servlet.ServletContext#addServlet}.
+ * This is generic configuration whether or not the <em>management context</em> is separate from <em>main context</em>.
+ */
+@ManagementContextConfiguration(value = ManagementContextType.ANY)
+@ConditionalOnWebApplication(type = Type.SERVLET)
+@ConditionalOnClass(AgentServlet.class)
+@ConditionalOnAvailableEndpoint(endpoint = JolokiaWebEndpoint.class, exposure = EndpointExposure.WEB)
+@EnableConfigurationProperties(JolokiaProperties.class)
+public class JolokiaServletAutoConfiguration {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Bean
+    public JolokiaServletRegistration jolokiaServletRegistration(JolokiaProperties properties,
+                                                      WebEndpointProperties webEndpointProperties, DispatcherServletPath dispatcherServletPath) {
+        return new JolokiaServletRegistration(properties.getConfig(), webEndpointProperties, dispatcherServletPath,
+            applicationContext);
+    }
+
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaServletRegistration.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaServletRegistration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2009-2023 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.actuator;
+
+import java.util.Map;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRegistration;
+import org.jolokia.server.core.http.AgentServlet;
+import org.jolokia.server.core.service.api.Restrictor;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.boot.webmvc.autoconfigure.DispatcherServletPath;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * {@link ServletContextInitializer} (which runs in {@link jakarta.servlet.ServletContainerInitializer}) that
+ * registers {@link AgentServlet} in management web context.
+ */
+public class JolokiaServletRegistration implements ServletContextInitializer {
+
+    private final Map<String, String> initParameters;
+    private final DispatcherServletPath dispatcherServletPath;
+    private final WebEndpointProperties webEndpointProperties;
+    private final ApplicationContext applicationContext;
+
+    public JolokiaServletRegistration(Map<String, String> initParameters,
+                                      WebEndpointProperties webEndpointProperties, DispatcherServletPath dispatcherServletPath, ApplicationContext applicationContext) {
+        this.initParameters = initParameters;
+        this.dispatcherServletPath = dispatcherServletPath;
+        this.webEndpointProperties = webEndpointProperties;
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void onStartup(ServletContext servletContext) {
+        // we can check
+        // webEndpointProperties.getExposure().getInclude().contains("jolokia")
+        // but it's enough to have @ConditionalOnAvailableEndpoint(JolokiaWebEndpoint.class) on this @Bean's
+        // containing @ManagementContextConfiguration
+
+        // we don't have to check the context path (which is configured differently for main and management contexts)
+        // because servlet registration is done within single ServletContext
+        // org.springframework.boot.autoconfigure.web.servlet.DispatcherServletPath.getPrefix() trims trailing "/"
+        String prefix = dispatcherServletPath.getPrefix();
+
+        // management.endpoints.web.base-path - defaults to /actuator and never ends with "/"
+        // even if you set it to "/"
+        String endpointsBasePath = webEndpointProperties.getBasePath();
+
+        String jolokiaPath = "jolokia";
+        Map<String, String> mapping = webEndpointProperties.getPathMapping();
+        if (mapping.containsKey(jolokiaPath)) {
+            jolokiaPath = mapping.get(jolokiaPath);
+        }
+
+        // https://github.com/jolokia/jolokia/issues/823
+        // restrictors can be taken from ApplicationContext (including its parent(s)) and Agent servlet will
+        // decide which one to use (it'll have access to LogHandler, so we're not logging anything here)
+        Map<String, Restrictor> restrictors = BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, Restrictor.class);
+        AgentServlet servlet = new AgentServlet();
+        servlet.getInitRestrictors().putAll(restrictors);
+
+        ServletRegistration.Dynamic reg = servletContext.addServlet("jolokia", servlet);
+        reg.setInitParameters(initParameters);
+        reg.addMapping(prefix + endpointsBasePath + "/" + jolokiaPath + "/*");
+    }
+
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaWebEndpoint.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaWebEndpoint.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2009-2023 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.actuator;
+
+import java.util.Map;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.boot.webmvc.autoconfigure.DispatcherServletPath;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * Jolokia actuator endpoint ({@code /actuator/jolokia}) which used to register a servlet, but now only
+ * registers a link under {@code /actuator} listing page.
+ */
+@WebEndpoint(id = "jolokia")
+public class JolokiaWebEndpoint {
+
+    private final ManagementServerProperties managementServerProperties;
+    private final WebEndpointProperties webEndpointProperties;
+    private final DispatcherServletPath dispatcherServletPath;
+
+    public JolokiaWebEndpoint(ManagementServerProperties managementServerProperties, WebEndpointProperties webEndpointProperties, DispatcherServletPath dispatcherServletPath) {
+        this.managementServerProperties = managementServerProperties;
+        this.webEndpointProperties = webEndpointProperties;
+        this.dispatcherServletPath = dispatcherServletPath;
+    }
+
+    /**
+     * This operation is not invoked, because actual {@link JolokiaServletRegistration Jolokia servlet registration}
+     * is overriding {@code /actuator/jolokia/*} mapping (taking into account actuator base/context path
+     * configuration). Only when Jolokia's servlet is not registered, this method will be used to redirect to
+     * non-existing {@code /version} URL.
+     * @return
+     */
+    @ReadOperation
+    public ModelAndView jolokia() {
+        // org.springframework.web.servlet.view.RedirectView which is used for "redirect:" is by default
+        // context-relative, so we don't have to check what is:
+        //  - server.servlet.context-path when there's one context
+        //  - management.server.base-path when server.port is different than management.server.port
+
+        // spring.mvc.servlet.path for "main" context and "/" for "management" context
+        // but we don't have to guess which one to use - we access it through proper DispatcherServletPath
+        String prefix = dispatcherServletPath.getPrefix();
+
+        // management.endpoints.web.base-path - defaults to /actuator
+        String endpointsBasePath = webEndpointProperties.getBasePath();
+
+        String jolokiaPath = "jolokia";
+        Map<String, String> mapping = webEndpointProperties.getPathMapping();
+        if (mapping.containsKey(jolokiaPath)) {
+            jolokiaPath = mapping.get(jolokiaPath);
+        }
+
+        return new ModelAndView("redirect:" + prefix + endpointsBasePath + "/" + jolokiaPath + "/version");
+    }
+
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaWebEndpointAutoConfiguration.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/actuator/JolokiaWebEndpointAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2009-2023 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.actuator;
+
+import org.jolokia.server.core.http.AgentServlet;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.expose.EndpointExposure;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.webmvc.autoconfigure.DispatcherServletPath;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+
+/**
+ * <p>This autoconfiguration ensures that we can see {@code /jolokia} link under {@code /actuator} page.
+ * We don't declare any {@link Bean} that registers a servlet or a controller.</p>
+ *
+ * <p>Note: Adding {@link ConditionalOnAvailableEndpoint} on the bean method that produces the endpoint in
+ * the first place is completely fine - related {@link Condition} will check proper exposure config amd
+ * Spring will not even create {@link JolokiaWebEndpoint} in the first place.</p>
+ */
+@AutoConfiguration
+@ConditionalOnWebApplication(type = Type.SERVLET)
+@ConditionalOnClass(AgentServlet.class)
+public class JolokiaWebEndpointAutoConfiguration {
+
+    @Bean
+    @ConditionalOnAvailableEndpoint(exposure = EndpointExposure.WEB)
+    public JolokiaWebEndpoint jolokiaManagementEndpoint(final ManagementServerProperties managementServerProperties,
+                                                        final WebEndpointProperties webEndpointProperties,
+                                                        final DispatcherServletPath dispatcherServletPath) {
+        return new JolokiaWebEndpoint(managementServerProperties, webEndpointProperties, dispatcherServletPath);
+    }
+
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/backend/SpringCommandHandler.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/backend/SpringCommandHandler.java
@@ -1,0 +1,47 @@
+package org.jolokia.support.spring.backend;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+
+import org.jolokia.server.core.request.JolokiaRequest;
+import org.jolokia.server.core.service.api.JolokiaContext;
+import org.jolokia.server.core.util.RequestType;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Base class for Jolokia commands accessing the spring container
+ *
+ * @author roland
+ * @since 02.12.13
+ */
+public abstract class SpringCommandHandler<T extends JolokiaRequest> {
+
+    // Spring application context
+    private final ApplicationContext applicationContext;
+
+    // The jolokia context used
+    private final JolokiaContext context;
+
+    protected SpringCommandHandler(ApplicationContext pAppContext, JolokiaContext pContext, RequestType pType) {
+        this.context = pContext;
+        this.type = pType;
+        this.applicationContext = pAppContext;
+    }
+
+    // Request type of this command
+    private final RequestType type;
+
+    public RequestType getType() {
+        return type;
+    }
+
+    public JolokiaContext getJolokiaContext() {
+        return context;
+    }
+
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    public abstract Object handleRequest(T pJmxReq, Object pPreviousResult) throws InstanceNotFoundException, AttributeNotFoundException;
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/backend/SpringListHandler.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/backend/SpringListHandler.java
@@ -1,0 +1,197 @@
+package org.jolokia.support.spring.backend;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jolokia.json.JSONArray;
+import org.jolokia.json.JSONObject;
+import org.jolokia.server.core.request.JolokiaListRequest;
+import org.jolokia.server.core.service.api.JolokiaContext;
+import org.jolokia.server.core.util.ClassUtil;
+import org.jolokia.server.core.util.JsonUtil;
+import org.jolokia.server.core.util.RequestType;
+import org.jolokia.service.jmx.handler.list.DataKeys;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.jolokia.service.jmx.handler.list.DataKeys.*;
+
+/**
+ * A handler for dealing with "list" requests. Currently only one application context
+ * is supported.
+ *
+ * @author roland
+ * @since 17.12.13
+ */
+public class SpringListHandler extends SpringCommandHandler<JolokiaListRequest> {
+
+    private static final String NAME_PREFIX = "name=";
+    private final static Map<Class<?>,String> WRAPPER_TO_PRIMITIVE;
+
+    public SpringListHandler(ApplicationContext pAppContext, JolokiaContext pJolokiaContext) {
+        super(pAppContext, pJolokiaContext, RequestType.LIST);
+    }
+
+    @Override
+    public Object handleRequest(JolokiaListRequest pJmxReq, Object pPreviousResult) {
+        String domain = getApplicationContext().getApplicationName();
+        if (domain.isEmpty()) {
+            domain = "default";
+        }
+        String providerAndDomain = SpringRequestHandler.PROVIDER + "@" + domain;
+        final BeanDefinition requestedBean=beanFromRequest(pJmxReq, providerAndDomain);
+        if(requestedBean != null) {
+            return getSpringBeanInfo(requestedBean);
+        }
+        else {
+            JSONObject ret = new JSONObject();
+            JSONObject beans = getAllSpringBeans(getAsConfigurableApplicationContext());
+            ret.put(providerAndDomain, beans);
+            return ret;
+        }
+    }
+
+    /**
+     * Try to match up the path segment of the request to a spring bean
+     * @return Bean definition corresponding to request, null if none
+     */
+    private BeanDefinition beanFromRequest(JolokiaListRequest pJmxReq, String providerAndDomain) {
+        List<String> pathParts = pJmxReq.getPathParts();
+        if(pathParts != null && pathParts.size() == 2 && providerAndDomain.equals(
+                pathParts.get(0))) {
+           final String beanAndName = pathParts.get(1);
+           if(beanAndName.toLowerCase().startsWith(NAME_PREFIX)) {
+               final String beanName=beanAndName.substring(NAME_PREFIX.length());
+               return getAsConfigurableApplicationContext().getBeanFactory().getMergedBeanDefinition(beanName);
+           }
+        }
+        return null;
+    }
+
+    // ====================================================================================
+
+    private JSONObject getAllSpringBeans(ConfigurableApplicationContext appCtx) {
+        ConfigurableBeanFactory bdFactory = appCtx.getBeanFactory();
+        JSONObject ret = new JSONObject();
+        // TODO: Fix for FactoryBeans
+        for (String beanName : appCtx.getBeanDefinitionNames()) {
+            BeanDefinition bd = bdFactory.getMergedBeanDefinition(beanName);
+            if(!bd.isAbstract()) {// avoid abstract beans as they are not actual beans in the context
+                ret.put(NAME_PREFIX + beanName, getSpringBeanInfo(bd));
+            }
+        }
+        return ret;
+    }
+
+    private JSONObject getSpringBeanInfo(BeanDefinition pBeanDef) {
+        JSONObject ret = new JSONObject();
+        ret.put(DESCRIPTION.getKey(),pBeanDef.getDescription());
+        final String beanClassName = pBeanDef.getBeanClassName();
+        if (beanClassName != null) {
+            Class<?> beanClass = ClassUtil.classForName(beanClassName);
+            if (beanClass != null) {
+                ret.put(ATTRIBUTES.getKey(), getAttributes(pBeanDef, beanClass));
+                ret.put(OPERATIONS.getKey(), getOperations(beanClass));
+            }
+        }
+        return ret;
+    }
+
+    private JSONObject getOperations(Class<?> pBeanClass) {
+        JSONObject ret = new JSONObject();
+        for (Method method : pBeanClass.getMethods()) {
+            int modifier = method.getModifiers();
+            if (Modifier.isPublic(modifier) &&
+                (modifier & (Modifier.ABSTRACT | Modifier.STATIC)) == 0) {
+                JSONObject oMap = new JSONObject();
+                oMap.put(ARGS.getKey(),extractArguments(method));
+                oMap.put(RETURN_TYPE.getKey(),classToString(method.getReturnType()));
+                JsonUtil.addJSONObjectToJSONObject(ret,method.getName(),oMap);
+            }
+        }
+        return ret;
+    }
+
+    private JSONArray extractArguments(Method method) {
+        JSONArray ret = new JSONArray(method.getParameterTypes().length);
+        int i = 0;
+        for (Class<?> paramType : method.getParameterTypes()) {
+            JSONObject params = new JSONObject();
+            params.put(TYPE.getKey(),classToString(paramType));
+            // Maybe extract real name when running under Java 8 with reflection and Method.getParameters()
+            // or by extracting debugging info (like Spring MVC does). For now we simply add dummy values;
+            params.put(NAME_PREFIX,"arg" + i++);
+            ret.add(params);
+        }
+        return ret;
+    }
+
+    private JSONObject getAttributes(BeanDefinition pBeanDef, Class<?> pBeanClass) {
+        JSONObject ret = new JSONObject();
+
+        addIfNotNull(ret, DESCRIPTION, pBeanDef.getDescription());
+        for (PropertyDescriptor propDesc : BeanUtils.getPropertyDescriptors(pBeanClass)) {
+            JSONObject aMap = new JSONObject();
+            Class<?> propType = propDesc.getPropertyType();
+            addIfNotNull(aMap, TYPE, propType != null ? classToString(propType) : null);
+            addIfNotNull(aMap, DESCRIPTION, propDesc.getShortDescription());
+            aMap.put(READ_WRITE.getKey(), propDesc.getWriteMethod() != null);
+            ret.put(propDesc.getName(),aMap);
+        }
+        return ret;
+    }
+
+    private ConfigurableApplicationContext getAsConfigurableApplicationContext() {
+        ApplicationContext appCtx = getApplicationContext();
+        if (! (appCtx instanceof  ConfigurableApplicationContext)) {
+            throw new IllegalArgumentException("Given Spring application context " + appCtx + " is not a " +
+                                               "ConfigurableApplicationContext");
+        }
+        return (ConfigurableApplicationContext) appCtx;
+    }
+
+    private void addIfNotNull(JSONObject pMap, DataKeys pKey, String pValue) {
+        if (pValue != null) {
+            pMap.put(pKey.getKey(),pValue);
+        }
+    }
+
+    // Class mapping for primitive values
+    static {
+        WRAPPER_TO_PRIMITIVE = new HashMap<>();
+        Object[] p = {
+                Boolean.TYPE, "boolean",
+                Character.TYPE, "character",
+                Byte.TYPE, "byte",
+                Short.TYPE, "short",
+                Integer.TYPE, "int",
+                Long.TYPE, "long",
+                Float.TYPE, "float",
+                Double.TYPE, "double",
+                Void.TYPE, "void"
+        };
+
+        for (int i = 0; i < p.length; i += 2) {
+            WRAPPER_TO_PRIMITIVE.put((Class<?>) p[i],(String) p[i+1]);
+        }
+    }
+
+    private String classToString(Class<?> pClass) {
+        if (pClass.isPrimitive()) {
+            String ret = WRAPPER_TO_PRIMITIVE.get(pClass);
+            if (ret == null) {
+                throw new IllegalStateException("Internal: No mapping for primitive type " + pClass + " found");
+            }
+            return ret;
+        } else {
+            return pClass.getCanonicalName();
+        }
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/backend/SpringReadHandler.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/backend/SpringReadHandler.java
@@ -1,0 +1,71 @@
+package org.jolokia.support.spring.backend;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.ObjectName;
+
+import org.jolokia.server.core.request.JolokiaReadRequest;
+import org.jolokia.server.core.service.api.JolokiaContext;
+import org.jolokia.server.core.util.RequestType;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * @author roland
+ * @since 02.12.13
+ */
+public class SpringReadHandler extends SpringCommandHandler<JolokiaReadRequest> {
+
+    protected SpringReadHandler(ApplicationContext pAppContext, JolokiaContext pContext) {
+        super(pAppContext, pContext, RequestType.READ);
+    }
+
+    @Override
+    public Object handleRequest(JolokiaReadRequest pJmxReq, Object pPreviousResult) throws InstanceNotFoundException, AttributeNotFoundException {
+        ObjectName oName = pJmxReq.getObjectName();
+        String beanName = oName.getKeyProperty("name");
+        if (beanName == null) {
+            beanName = oName.getKeyProperty("id");
+        }
+        if (beanName == null) {
+            throw new IllegalArgumentException("No bean name given with property 'name' when requesting " + oName);
+        }
+
+        ApplicationContext ctx = getApplicationContext();
+        try {
+            Object bean = ctx.getBean(beanName);
+            Class<?> clazz = bean.getClass();
+            String attribute = pJmxReq.getAttributeName();
+            if (attribute == null) {
+                throw new UnsupportedOperationException("Multi attribute read not implemented yet");
+            }
+            // Try get method first
+            Method getter = ReflectionUtils.findMethod(
+                clazz, "get" + attribute.substring(0, 1).toUpperCase() + attribute.substring(1));
+            if (getter != null) {
+                return ReflectionUtils.invokeMethod(getter,bean);
+            }
+
+            // Next: Direct field access
+            Field field = ReflectionUtils.findField(clazz,attribute);
+            if (field != null) {
+                boolean isAccessible = field.canAccess(bean);
+                field.setAccessible(true);
+                try {
+                    return ReflectionUtils.getField(field,bean);
+                } finally {
+                    field.setAccessible(isAccessible);
+                }
+            }
+            throw new AttributeNotFoundException("No attribute " + attribute +
+                                                 " found on bean " + beanName + "(class " + clazz + ") while processing " + oName);
+
+        } catch (NoSuchBeanDefinitionException exp) {
+            throw (InstanceNotFoundException)
+                    new InstanceNotFoundException("No bean with name " + beanName + " found in application context").initCause(exp);
+        }
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/backend/SpringRequestHandler.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/backend/SpringRequestHandler.java
@@ -1,0 +1,67 @@
+package org.jolokia.support.spring.backend;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.management.JMException;
+
+import org.jolokia.server.core.request.JolokiaRequest;
+import org.jolokia.server.core.service.api.JolokiaContext;
+import org.jolokia.server.core.service.request.AbstractRequestHandler;
+import org.jolokia.server.core.service.request.RequestHandler;
+import org.jolokia.server.core.util.RequestType;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * A request handler which expose the Spring application context over the
+ * the Jolokia protocol
+ *
+ * @author roland
+ * @since 22.10.13
+ */
+public class SpringRequestHandler extends AbstractRequestHandler
+        implements RequestHandler {
+
+    public static final String PROVIDER = "spring";
+
+    // Application context for looking up beans
+    private final ApplicationContext appContext;
+
+    // Map for getting to the proper command handler
+    private final Map<RequestType,SpringCommandHandler<?>> commandHandlerMap = new HashMap<>();
+
+    /**
+     * Construction of a spring request handler
+     *
+     * @param pAppContext the application context from where to fetch the spring beans
+     * @param pOrder order of this service
+     */
+    public SpringRequestHandler(ApplicationContext pAppContext, int pOrder) {
+        super(PROVIDER, pOrder);
+        this.appContext = pAppContext;
+    }
+
+    /** {@inheritDoc} */
+    public <R extends JolokiaRequest> Object handleRequest(R pJmxReq, Object pPreviousResult) throws JMException {
+        @SuppressWarnings("unchecked")
+        SpringCommandHandler<R> handler = (SpringCommandHandler<R>) commandHandlerMap.get(pJmxReq.getType());
+        if (handler == null) {
+            throw new UnsupportedOperationException("No spring command handler for type " + pJmxReq.getType() + " registered");
+        }
+        return handler.handleRequest(pJmxReq, pPreviousResult);
+    }
+
+    @Override
+    public void init(JolokiaContext pJolokiaContext) {
+        for (SpringCommandHandler<?> handler : new SpringCommandHandler<?>[] {
+                new SpringReadHandler(appContext, pJolokiaContext),
+                new SpringListHandler(appContext, pJolokiaContext)
+        }) {
+            commandHandlerMap.put(handler.getType(), handler);
+        }
+    }
+
+    @Override
+    public boolean canHandle(JolokiaRequest pJolokiaRequest) {
+        return super.canHandle(pJolokiaRequest) && this.commandHandlerMap.containsKey(pJolokiaRequest.getType());
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/config/AgentBeanDefinitionParser.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/config/AgentBeanDefinitionParser.java
@@ -1,0 +1,71 @@
+package org.jolokia.support.spring.config;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jolokia.support.spring.SpringJolokiaAgent;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
+
+/**
+ * Bean definition parser for a &lt;jolokia:agent&gt; spring configuration
+ *
+ */
+public class AgentBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+    @Override
+    @SuppressWarnings("NullableProblems")
+    protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+        Element config = DomUtils.getChildElementByTagName(element,"config");
+        if (config != null) {
+            builder.addPropertyValue("config", parserContext.getDelegate().parseCustomElement(config,builder.getRawBeanDefinition()));
+        }
+        Element log = DomUtils.getChildElementByTagName(element,"log");
+        if (log != null) {
+            LogBeanDefinitionParser logParser = new LogBeanDefinitionParser();
+            builder.addPropertyValue("logHandler", logParser.parseInternal(log,parserContext));
+        }
+        for (String lookupKey : new String[] { "lookupConfig", "lookupServices" } ) {
+            String lookup = element.getAttribute(lookupKey);
+            builder.addPropertyValue(lookupKey,
+                                     StringUtils.hasLength(lookup) &&
+                                     Boolean.parseBoolean(lookup));
+        }
+        String systemPropertiesMode = element.getAttribute("systemPropertiesMode");
+        if (StringUtils.hasLength(systemPropertiesMode)) {
+            builder.addPropertyValue("systemPropertiesMode",systemPropertiesMode);
+        }
+        String exposeApplicationContext = element.getAttribute("exposeApplicationContext");
+        if (StringUtils.hasLength(exposeApplicationContext)) {
+            builder.addPropertyValue("exposeApplicationContext",exposeApplicationContext);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("NullableProblems")
+    protected Class<?> getBeanClass(Element element) {
+        return SpringJolokiaAgent.class;
+    }
+
+    @Override
+    protected boolean shouldGenerateIdAsFallback() {
+        return true;
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/config/ConfigBeanDefinitionParser.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/config/ConfigBeanDefinitionParser.java
@@ -1,0 +1,96 @@
+package org.jolokia.support.spring.config;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jolokia.support.spring.SpringJolokiaConfigHolder;
+import org.springframework.beans.factory.config.TypedStringValue;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedMap;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+
+/**
+ * Definition parser for "config"
+ *
+* @author roland
+* @since 29.12.12
+*/
+class ConfigBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+    // Properties to ignore for setting the configuration
+    private static final String[] SKIP_ATTRIBUTES = {
+            "order",
+            "xmlns",
+            "xmlns:xsi",
+            "xsi:schemaLocation",
+            "id"
+    };
+
+    private final Set<String>         skipMap;
+
+    ConfigBeanDefinitionParser() {
+        skipMap = new HashSet<>(Arrays.asList(SKIP_ATTRIBUTES));
+    }
+
+    @Override
+    protected void doParse(Element element, @SuppressWarnings("NullableProblems") ParserContext parserContext, BeanDefinitionBuilder builder) {
+        Map<String, Object> config = new HashMap<>();
+        builder.addPropertyValue("config",createConfigMap(element.getAttributes()));
+        String order = element.getAttribute("order");
+        if (StringUtils.hasText(order)) {
+            builder.addPropertyValue("order",Integer.parseInt(order));
+        }
+    }
+
+    private Map<Object, Object> createConfigMap(NamedNodeMap attributes) {
+        ManagedMap<Object, Object> map = new ManagedMap<>(attributes.getLength());
+		map.setKeyTypeName("java.lang.String");
+		map.setValueTypeName("java.lang.String");
+
+        for (int i = 0;i < attributes.getLength(); i++) {
+            Attr attr = (Attr) attributes.item(i);
+            String name = attr.getName();
+            if (skipMap.contains(name)) {
+                continue;
+            }
+            Object key = new TypedStringValue(name, String.class);
+            Object value = new TypedStringValue(attr.getValue(),String.class);
+            map.put(key,value);
+        }
+        return map;
+    }
+
+    @Override
+    protected Class<?> getBeanClass(@SuppressWarnings("NullableProblems") Element element) {
+        return SpringJolokiaConfigHolder.class;
+    }
+
+    @Override
+    protected boolean shouldGenerateIdAsFallback() {
+        return true;
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/config/JolokiaNamespaceHandler.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/config/JolokiaNamespaceHandler.java
@@ -1,0 +1,35 @@
+package org.jolokia.support.spring.config;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * @author roland
+ * @since 29.12.12
+ */
+public class JolokiaNamespaceHandler extends NamespaceHandlerSupport {
+
+    /** {@inheritDoc} */
+    public void init() {
+        registerBeanDefinitionParser("agent",new AgentBeanDefinitionParser());
+        registerBeanDefinitionParser("mbean-server",new MBeanServerBeanDefinitionParser());
+        registerBeanDefinitionParser("config",new ConfigBeanDefinitionParser());
+        registerBeanDefinitionParser("log", new LogBeanDefinitionParser());
+    }
+
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/config/LogBeanDefinitionParser.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/config/LogBeanDefinitionParser.java
@@ -1,0 +1,38 @@
+package org.jolokia.support.spring.config;
+
+import org.jolokia.support.spring.SpringJolokiaLogHandlerHolder;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+/**
+ * Handler for parsing "log" configurations
+ *
+ * @author roland
+ * @since 17.10.13
+ */
+public class LogBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+    protected AbstractBeanDefinition parseInternal(Element element, @SuppressWarnings("NullableProblems") ParserContext parserContext) {
+        BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(SpringJolokiaLogHandlerHolder.class);
+        String logRef = element.getAttribute("log-ref");
+        if (StringUtils.hasLength(logRef)) {
+            builder.addPropertyReference("logHandler",logRef);
+        }
+        for (String attr : new String[]{ "type", "category"}) {
+            String val = element.getAttribute(attr);
+            if (StringUtils.hasLength(val)) {
+                builder.addPropertyValue(attr,val);
+            }
+        }
+        return builder.getBeanDefinition();
+    }
+
+    @Override
+    protected boolean shouldGenerateIdAsFallback() {
+        return true;
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/config/MBeanServerBeanDefinitionParser.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/config/MBeanServerBeanDefinitionParser.java
@@ -1,0 +1,40 @@
+package org.jolokia.support.spring.config;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jolokia.support.spring.SpringJolokiaMBeanServerFactory;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.w3c.dom.Element;
+
+/**
+ * Definition parser for "mbean-server"
+ *
+ * @author roland
+ * @since 11.02.13
+ */
+public class MBeanServerBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+    @Override
+    protected Class<?> getBeanClass(@SuppressWarnings("NullableProblems") Element element) {
+        return SpringJolokiaMBeanServerFactory.class;
+    }
+
+    @Override
+    protected boolean shouldGenerateIdAsFallback() {
+        return true;
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/log/CommonsLogHandler.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/log/CommonsLogHandler.java
@@ -1,0 +1,46 @@
+package org.jolokia.support.spring.log;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jolokia.server.core.service.api.LogHandler;
+
+/**
+ * Log Handler using Commons Logging (which is a dependency of Spring anyways).
+ *
+ * @author roland
+ * @since 17.10.13
+ */
+public class CommonsLogHandler implements LogHandler {
+
+    private final Log log;
+
+    /**
+     * Constructor for a {@link LogHandler} using commons logging
+     *
+     * @param pCategory the logging category. If null, org.jolokia is used as category
+     */
+    public CommonsLogHandler(String pCategory) {
+        log = LogFactory.getLog(pCategory != null ? pCategory : "org.jolokia");
+    }
+
+    /** {@inheritDoc} */
+    public void debug(String message) {
+        log.debug(message);
+    }
+
+    /** {@inheritDoc} */
+    public void info(String message) {
+        log.info(message);
+    }
+
+    /** {@inheritDoc} */
+    public void error(String message, Throwable t) {
+        log.error(message,t);
+    }
+
+    /** {@inheritDoc} */
+    public boolean isDebug() {
+        return log.isDebugEnabled();
+    }
+
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/log/Log4j2LogHandler.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/log/Log4j2LogHandler.java
@@ -1,0 +1,45 @@
+package org.jolokia.support.spring.log;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jolokia.server.core.service.api.LogHandler;
+
+/**
+ * Loghandler using Log4j Version 2
+ *
+ * @author roland
+ * @since 21.10.13
+ */
+public class Log4j2LogHandler implements LogHandler {
+
+    private final Logger logger;
+
+    /**
+     * Constructor for a {@link LogHandler} using Log4J, version 2
+     *
+     * @param pCategory the logging category. If null, org.jolokia is used as category
+     */
+    public Log4j2LogHandler(String pCategory) {
+        logger = LogManager.getLogger(pCategory != null ? pCategory : "org.jolokia" );
+    }
+
+    /** {@inheritDoc} */
+    public void debug(String message) {
+        logger.debug(message);
+    }
+
+    /** {@inheritDoc} */
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    /** {@inheritDoc} */
+    public void error(String message, Throwable t) {
+        logger.error(message,t);
+    }
+
+    /** {@inheritDoc} */
+    public boolean isDebug() {
+        return logger.isDebugEnabled();
+    }
+}

--- a/support/spring7/src/main/java/org/jolokia/support/spring/log/Slf4jLogHandler.java
+++ b/support/spring7/src/main/java/org/jolokia/support/spring/log/Slf4jLogHandler.java
@@ -1,0 +1,45 @@
+package org.jolokia.support.spring.log;
+
+import org.jolokia.server.core.service.api.LogHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Loghandler using SLF4J
+ *
+ * @author roland
+ * @since 21.10.13
+ */
+public class Slf4jLogHandler implements LogHandler {
+
+    private final Logger logger;
+
+    /**
+     * Constructor for a {@link LogHandler} using commons SLF4J
+     *
+     * @param pCategory the logging category. If null, org.jolokia is used as category
+     */
+    public Slf4jLogHandler(String pCategory) {
+        logger = LoggerFactory.getLogger(pCategory != null ? pCategory : "org.jolokia");
+    }
+
+    /** {@inheritDoc} */
+    public void debug(String message) {
+        logger.debug(message);
+    }
+
+    /** {@inheritDoc} */
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    /** {@inheritDoc} */
+    public void error(String message, Throwable t) {
+        logger.error(message,t);
+    }
+
+    /** {@inheritDoc} */
+    public boolean isDebug() {
+        return logger.isDebugEnabled();
+    }
+}

--- a/support/spring7/src/main/resources/META-INF/spring.handlers
+++ b/support/spring7/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,17 @@
+#
+# Copyright 2009-2023 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+http\://www.jolokia.org/jolokia-spring/schema/config=org.jolokia.support.spring.config.JolokiaNamespaceHandler

--- a/support/spring7/src/main/resources/META-INF/spring.schemas
+++ b/support/spring7/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,22 @@
+#
+# Copyright 2009-2023 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# old locations
+http\://www.jolokia.org/jolokia-spring/schema/config/jolokia-config.xsd=org/jolokia/support/spring/jolokia-config.xsd
+https\://www.jolokia.org/jolokia-spring/schema/config/jolokia-config.xsd=org/jolokia/support/spring/jolokia-config.xsd
+# new locations
+http\://www.jolokia.org/jolokia-config.xsd=org/jolokia/support/spring/jolokia-config.xsd
+https\://www.jolokia.org/jolokia-config.xsd=org/jolokia/support/spring/jolokia-config.xsd

--- a/support/spring7/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
+++ b/support/spring7/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
@@ -1,0 +1,21 @@
+#
+# Copyright 2009-2025 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# autoconfiguration of beans that go to "management" context
+
+# autoconfiguration that registers a @Bean which is org.springframework.boot.web.servlet.ServletContextInitializer
+# that registers actual Jolokia servlet into management web context
+org.jolokia.support.spring.actuator.JolokiaServletAutoConfiguration

--- a/support/spring7/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/support/spring7/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,21 @@
+#
+# Copyright 2009-2025 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# autoconfiguration of beans that go to "main" context
+
+# autoconfiguration that registers a @Bean with @WebEndpoint, so we can see Jolokia endpoint under
+# /actuator page listing all endpoints like "/health"
+org.jolokia.support.spring.actuator.JolokiaWebEndpointAutoConfiguration

--- a/support/spring7/src/main/resources/org/jolokia/support/spring/jolokia-config.xsd
+++ b/support/spring7/src/main/resources/org/jolokia/support/spring/jolokia-config.xsd
@@ -1,0 +1,589 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2013  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://www.jolokia.org/jolokia-spring/schema/config"
+           targetNamespace="http://www.jolokia.org/jolokia-spring/schema/config"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <!-- Declaration of a Jolokia server -->
+  <xs:element name="agent">
+    <xs:annotation>
+      <xs:documentation source="org.jolokia.support.spring.SpringJolokiaAgent">
+        A JVM Jolokia agent for exposing JMX via Jolokia.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <!-- Configuration used -->
+        <xs:element name="config" type="tns:Config" minOccurs="0" maxOccurs="1"/>
+        <!-- LogHandler to use -->
+        <xs:element name="log" type="tns:Log" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            Optional id for specifying this servers name as it
+            can be referenced from the Spring application context.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="lookupConfig" type="xs:boolean" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            If set to true, externally defined configurations are looked
+            up and used according to their order in addition to the configuration
+            defined withing this tag.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="lookupServices" type="xs:boolean" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            If set to true, externally defined Jolokia-services are looked up
+            and added to the set of services to use. Please refer to the documentation
+            of org.jolokia.server.core.service.api.JolokiaService for details.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="exposeApplicationContext" type="xs:boolean" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            If set to true, the application context itself is exposed over the Jolokia protocol.
+            The container can be reached by using the provider prefix 'spring@'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="systemPropertiesMode">
+        <xs:annotation>
+          <xs:documentation><![CDATA[
+  Configuration for the Jolokia server can be looked up from system properties, too. Any system
+  property starting with "jolokia." is considered to be a configuration option where the configuration
+  key is the part after "jolokia.". Several modes are available for how system properties should be used.
+  By default, no lookup for system properties is performed.
+
+  "never" indicates no system properties should be looked up. This is the default.
+	"fallback" indicates system properties should be used as fallback if no local configuration is given
+	"override" indicates system properties should override any local configuration with highest priority
+          ]]></xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="never"/>
+            <xs:enumeration value="fallback"/>
+            <xs:enumeration value="override"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Configuration for the Jolokia server -->
+  <xs:element name="config" type="tns:Config"/>
+
+  <!-- Jolokia MBeanServer-->
+  <xs:element name="mbean-server">
+    <xs:annotation>
+      <xs:documentation source="org.jolokia.support.spring.SpringJolokiaMBeanServerFactory">
+        The Jolokia MBeanServer which can be used to hide MBean from JSR-160 exports and for
+        handling @JsonMBeans.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID">
+        <xs:annotation>
+          <xs:documentation>
+            Id for specifying this servers name as it
+            can be referenced from the Spring application context.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ============================================================================== -->
+
+  <xs:complexType name="Log">
+    <xs:annotation>
+      <xs:documentation source="org.jolokia.support.spring.SpringJolokiaLogHandlerHolder">
+        Configuration for a log handler to be used.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="log-ref" type="xs:IDREF">
+      <xs:annotation>
+        <xs:documentation>
+          Referenced to a Spring Bean implementing org.jolokia.server.core.service.api.LogHandler which then is used
+          for logging.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="type">
+      <xs:annotation>
+        <xs:documentation>
+          Specify which logging backend to use. Available are "log4j2" for Log4J2, "slf4j" for SLF4J,
+          "jul" for java.util.logging, "commons" for Commons Logging and "logback" for, well, LogBack.
+          The corresponding libraries must be in the classpath, otherwise things get nasty.
+          How I love this logging heaven !
+        </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="log4j2"/>
+          <xs:enumeration value="slf4j"/>
+          <xs:enumeration value="jul"/>
+          <xs:enumeration value="commons"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="category" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          The logging category used (and yes, I still call it "category" ;-). By default it's
+          "org.jolokia".
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+
+  <!-- Type definition for the configuration -->
+  <xs:complexType name="Config">
+    <xs:annotation>
+      <xs:documentation source="org.jolokia.support.spring.SpringJolokiaConfigHolder">
+        Configuration for a Jolokia JVM agent
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="id" type="xs:ID" use="optional"/>
+    <xs:attribute name="order" type="xs:int">
+      <xs:annotation>
+        <xs:documentation>
+          Order in which configuration should be applied. This attribute is
+          only used when the &lt;jolokia:server&gt;
+          is configured with "lookup-config" set to true. If multiple
+          &lt;jolokia:config&gt; config objects exist, they get applied in the provided
+          order. This attribute is ignored when using &lt;jolokia:config&gt; within a
+          &lt;jolokia:server&gt; configuration. Embedded configuration always serves as
+          default value with the lowest precedence. The higher the
+          order the higher the importance/precedence configuration is.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="host" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Host address to listen to. Default is InetAddress.getLocalHost()
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="port" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Port to listen to. Default is 8778.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="autoStart" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          Whether to start the Jolokia server automatically. Default is true.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <!--
+    private String      context;
+    -->
+
+    <xs:attribute name="protocol">
+      <xs:annotation>
+        <xs:documentation>
+          Protocol to use for communication. Can be either "http" or "https".
+        </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="http"/>
+          <xs:enumeration value="https"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attribute name="executor">
+      <xs:annotation>
+        <xs:documentation>
+          Threading model of the HTTP server:
+          "fixed" -- Thread pool with a fixed number of threads (see also "thread-nr"),
+          "cached" -- Cached thread pool which creates threads on demand,
+          "single" -- A single thread only
+        </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="fixed"/>
+          <xs:enumeration value="cached"/>
+          <xs:enumeration value="single"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attribute name="threadNamePrefix" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Thread name prefix that executor will use while creating new thread(s)
+          (default: jolokia-)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="threadNr" type="xs:positiveInteger">
+      <xs:annotation>
+        <xs:documentation>
+          Number of threads to use when the execution model is configured to "fixed".
+          (See attribute "executor")
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="backlog" type="xs:positiveInteger">
+      <xs:annotation>
+        <xs:documentation>
+          Size of request backlog before requests get discarded.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="useSslAuthentication" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          Whether client certificates should be used for authentication (https only).
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="keystore" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Path to the SSL keystore to use (https only)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="keystorePassword" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Keystore password (https only)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="secureSocketProtocol" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Secure protocol (https only, default: TLS)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="keyStoreType" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Keystore type (https only, default: JKS)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="keyManagerAlgorithm" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Key manager algorithm (https only, default: SunX509)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="trustManagerAlgorithm" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Trust manager algorithm (https only, default: SunX509)
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <!-- Jolokia generic config (see enum ConfigKey) -->
+    <xs:attribute name="user" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          User which is allowed to connect
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="password" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Password for authenticating the user.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="realm" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Security realm to use
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="authMode">
+      <xs:annotation>
+        <xs:documentation>
+          What authentication to use. Support values: "basic" for basic authentication, "jaas" for
+          JaaS authentication.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="basic"/>
+          <xs:enumeration value="jaas"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attribute name="authMatch">
+      <xs:annotation>
+        <xs:documentation>
+          If MultiAuthenticator is used, this config item explains how to combine multiple authenticators.
+          Supported values: "any" at least one authenticator must match, "all" all authenticators must match.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="any"/>
+          <xs:enumeration value="all"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attribute name="authenticatorClass" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Custom authenticator to be used instead of default user/password one.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="agentContext" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Context under which the agent is deployed. The full URL
+          will be protocol://host:port/context
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="agentId" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          The ID to uniquely identify this agent within a JVM. There
+          can be multiple agents registered a JVM. This id is e.g. used to
+          uniquely create MBean names.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="agentDescription" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          A description which can be used to describe the agent further. Typically
+          this can be used by clients to provide additional information to
+          the user.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="historyMaxEntries" type="xs:positiveInteger">
+      <xs:annotation>
+        <xs:documentation>
+          Maximum number of history entries to keep
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="debug" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          Whether debug is switched on or not
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="debugMaxEntries" type="xs:positiveInteger">
+      <xs:annotation>
+        <xs:documentation>
+          Maximum number of debug entries to hold
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="maxDepth" type="xs:positiveInteger">
+      <xs:annotation>
+        <xs:documentation>
+          Maximum traversal depth for serialization of complex objects.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="maxCollectionSize" type="xs:positiveInteger">
+      <xs:annotation>
+        <xs:documentation>
+          Maximum size of collections returned during serialization.
+          If larger, the collection is truncated
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="maxObjects" type="xs:positiveInteger">
+      <xs:annotation>
+        <xs:documentation>
+          Maximum number of objects returned by serialization
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="canonicalNaming" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          This option specifies in which order the key-value
+          properties within ObjectNames as returned by
+          "list" or "search" are
+          returned. By default this is the so called 'canonical order'
+          in which the keys are sorted alphabetically. If this option
+          is set to false, then the natural order
+          is used, i.e. the object name as it was registered. This
+          option can be overridden with a query parameter of the same
+          name. By default this option is set to 'true'.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="includeStackTrace">
+      <xs:annotation>
+        <xs:documentation>
+          Whether to include a stacktrace of an exception in case of
+          an error. By default it it set to "true"
+          in which case the stacktrace is always included. If set to
+          "false", no stacktrace is included. If
+          the value is "runtime" a stacktrace is
+          only included for RuntimeExceptions. This global option can
+          be overridden with a query parameter.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="true"/>
+          <xs:enumeration value="false"/>
+          <xs:enumeration value="runtime"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attribute name="serializeException" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          When this parameter is set to "true",
+          then an exception thrown will be serialized as JSON and
+          included in the response under the key
+          "error_value". No stack trace information
+          will be included, though. This global option can be
+          overridden by a query parameter of the same name.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="restrictorClass" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Classname of an custom restrictor which must be loadable from the classpath
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="policyLocation" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Location of the policy file
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="mbeanQualifier" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Optional domain name for registering own MBeans
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="mimeType">
+      <xs:annotation>
+        <xs:documentation>
+          Mime Type to use for the response value. By default, this is
+          "text/plain", but it could be useful to return
+          "application/json", too.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="text/plain"/>
+          <xs:enumeration value="application/json"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+
+    <xs:attribute name="logHandlerClass" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Class specifying a loghandler to use. This class requires a now argument
+          constructor.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="discoveryEnabled" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          Whether to enable listening and responding to discovery multicast requests
+          for discovering agent details.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+    <xs:attribute name="discoveryAgentUrl" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Specify the agent URL to return for an discovery multicast request. If this option
+          is given "discoveryEnabled" is set to 'true' automatically. The URL given can contain placeholders:
+          "$host" or "${host}" : Host name (if possible), otherwise address --
+          "$ip" or "${ip}" : IP Address --
+          "${prop:foo}" : System property foo --
+          "${env:FOO}" : Environment variable FOO --
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+
+  </xs:complexType>
+  </xs:schema>

--- a/support/spring7/src/test/java/org/jolokia/support/spring/BaseServerTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/BaseServerTest.java
@@ -1,0 +1,47 @@
+package org.jolokia.support.spring;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.net.URL;
+
+import org.jolokia.server.core.Version;
+import org.jolokia.test.util.EnvTestUtil;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author roland
+ * @since 29.12.12
+ */
+class BaseServerTest {
+
+    protected void checkServerAndStop(SpringJolokiaAgent server) throws Exception {
+        //Thread.sleep(2000);
+        try {
+            URL url = new URL(server.getUrl());
+            System.out.println(">>> URL to check: " + server.getUrl());
+            String resp = EnvTestUtil.readToString(url.openStream());
+            assertTrue(resp.matches(".*type.*version.*") && resp.matches(".*" + Version.getAgentVersion() + ".*"));
+        } finally {
+            server.destroy();
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException ignored) {
+            }
+        }
+    }
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/DummyRequestHandler.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/DummyRequestHandler.java
@@ -1,0 +1,24 @@
+package org.jolokia.support.spring;
+
+import org.jolokia.server.core.request.JolokiaRequest;
+import org.jolokia.server.core.service.request.AbstractRequestHandler;
+
+/**
+ * @author roland
+ * @since 22.10.13
+ */
+public class DummyRequestHandler extends AbstractRequestHandler {
+
+    protected DummyRequestHandler() {
+        super("dummy",0);
+    }
+
+    public Object handleRequest(JolokiaRequest pJmxReq, Object pPreviousResult) {
+        return null;
+    }
+
+    public boolean canHandle(JolokiaRequest pJolokiaRequest) {
+        return false;
+    }
+
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/JolokiaServerIntegrationTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/JolokiaServerIntegrationTest.java
@@ -1,0 +1,58 @@
+package org.jolokia.support.spring;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import javax.management.MBeanServer;
+
+import org.jolokia.jvmagent.JolokiaServerConfig;
+import org.jolokia.test.util.EnvTestUtil;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author roland
+ * @since 29.12.12
+ */
+public class JolokiaServerIntegrationTest extends BaseServerTest {
+
+    @Test
+    public void simple() throws Exception {
+        System.setProperty("jolokia.port", "" + EnvTestUtil.getFreePort());
+        System.out.println("Port selected: " + System.getProperty("jolokia.port"));
+        ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("/spring-jolokia-context.xml");
+        SpringJolokiaAgent server = (SpringJolokiaAgent) ctx.getBean("jolokia");
+        JolokiaServerConfig cfg = server.getServerConfig();
+        assertEquals(cfg.getContextPath(),"/j4p/");
+
+        MBeanServer mbeanServer = (MBeanServer) ctx.getBean("jolokiaMBeanServer");
+        assertNotNull(mbeanServer);
+        //Thread.sleep(1000 * 3600);
+        checkServerAndStop(server);
+    }
+
+    @Test
+    public void withPlainBean() throws Exception {
+        System.setProperty("jolokia.port", "" + EnvTestUtil.getFreePort());
+        ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("/spring-jolokia-plain-beans.xml");
+        SpringJolokiaAgent server = (SpringJolokiaAgent) ctx.getBean("jolokia");
+        JolokiaServerConfig cfg = server.getServerConfig();
+        assertEquals(cfg.getContextPath(),"/jolokia");
+        checkServerAndStop(server);
+    }
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/SpringJolokiaLogHandlerHolderTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/SpringJolokiaLogHandlerHolderTest.java
@@ -1,0 +1,74 @@
+package org.jolokia.support.spring;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.jolokia.support.spring.log.CommonsLogHandler;
+import org.jolokia.server.core.service.api.LogHandler;
+import org.jolokia.support.spring.log.Log4j2LogHandler;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author roland
+ * @since 18.10.13
+ */
+public class SpringJolokiaLogHandlerHolderTest {
+    @Test
+    public void logHandlerProp() {
+        SpringJolokiaLogHandlerHolder holder = new SpringJolokiaLogHandlerHolder();
+        LogHandler handler = new CommonsLogHandler(null);
+        holder.setLogHandler(handler);
+        holder.afterPropertiesSet();
+        assertEquals(holder.getLogHandler(), handler);
+    }
+
+    @Test
+    public void logHandlerViaType() {
+        SpringJolokiaLogHandlerHolder holder = new SpringJolokiaLogHandlerHolder();
+        holder.setType("log4j2");
+        holder.setCategory("JOLOKIA");
+        holder.afterPropertiesSet();
+        Log4j2LogHandler logHandler = (Log4j2LogHandler) holder.getLogHandler();
+        Logger logger = (Logger) ReflectionTestUtils.getField(logHandler, "logger");
+        assertEquals(logger.getName(),"JOLOKIA");
+    }
+
+    @Test
+    public void checkAllTypes() {
+        List<String> types = new ArrayList<>();
+        for (SpringJolokiaLogHandlerHolder.LogHandlerType t :
+                SpringJolokiaLogHandlerHolder.LogHandlerType.values()) {
+            types.add((String) ReflectionTestUtils.getField(t, "type"));
+        }
+        for (String type : types) {
+            SpringJolokiaLogHandlerHolder holder = new SpringJolokiaLogHandlerHolder();
+            holder.setType(type);
+            holder.afterPropertiesSet();
+            LogHandler logHandler = holder.getLogHandler();
+            assertTrue(logHandler.getClass().getName().toLowerCase().contains(type.toLowerCase()));
+            logHandler.info("info");
+            logHandler.debug("debug");
+            logHandler.error("error", new Exception());
+            logHandler.isDebug();
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = ".*((log-ref|type).*){2}.*")
+    public void noTypeGiven() {
+        SpringJolokiaLogHandlerHolder holder = new SpringJolokiaLogHandlerHolder();
+        holder.afterPropertiesSet();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+    expectedExceptionsMessageRegExp = ".*bla.*")
+    public void invalidType() {
+        SpringJolokiaLogHandlerHolder holder = new SpringJolokiaLogHandlerHolder();
+        holder.setType("bla");
+        holder.afterPropertiesSet();
+    }
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/SpringJolokiaServerTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/SpringJolokiaServerTest.java
@@ -1,0 +1,120 @@
+package org.jolokia.support.spring;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jolokia.jvmagent.JolokiaServerConfig;
+import org.springframework.context.ApplicationContext;
+import org.testng.annotations.Test;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author roland
+ * @since 29.12.12
+ */
+public class SpringJolokiaServerTest extends BaseServerTest {
+
+    @Test
+    public void withoutStart() throws Exception {
+        SpringJolokiaAgent server = new SpringJolokiaAgent();
+        server.setConfig(getConfig(false,100));
+        server.afterPropertiesSet();
+        server.start();
+        checkServerAndStop(server);
+    }
+
+    @Test
+    public void systemProperties() throws Exception {
+        checkSystemPropertyMode("fallback","/jol/","/j4p/","/j4p/");
+        checkSystemPropertyMode("fallback","/jol/",null,"/jol/");
+        checkSystemPropertyMode("fallback",null,null,"/jolokia");
+
+        checkSystemPropertyMode("override","/jol/","/j4p/","/jol/");
+        checkSystemPropertyMode("override","/jol/",null,"/jol/");
+        checkSystemPropertyMode("override",null,null,"/jolokia");
+
+        checkSystemPropertyMode(null,"/jol/",null,"/jolokia");
+    }
+
+    private void checkSystemPropertyMode(String mode,String propContext,String configContext,String expectContext) throws Exception {
+        if (propContext != null) {
+            System.setProperty("jolokia.agentContext", propContext);
+        }
+        SpringJolokiaAgent server = new SpringJolokiaAgent();
+        server.setConfig(getConfig(true,100,"agentContext", configContext));
+        server.setSystemPropertiesMode(mode);
+        server.afterPropertiesSet();
+        assertEquals(server.getServerConfig().getContextPath(), expectContext);
+        System.getProperties().remove("jolokia.agentContext");
+        checkServerAndStop(server);
+        // Allow to shutdown server ...
+        Thread.sleep(500);
+    }
+
+    @Test
+    public void withStart() throws Exception {
+        SpringJolokiaAgent server = new SpringJolokiaAgent();
+        server.setConfig(getConfig(true,100));
+        server.afterPropertiesSet();
+        checkServerAndStop(server);
+    }
+
+    @Test
+    public void withMultiConfigAndStart() throws Exception {
+        SpringJolokiaAgent server = new SpringJolokiaAgent();
+        server.setLookupConfig(true);
+        server.setConfig(getConfig(true,100));
+
+        ApplicationContext ctx = createMock(ApplicationContext.class);
+        Map<String,SpringJolokiaConfigHolder> configs = new HashMap<>();
+        configs.put("B",getConfig(false,10,"executor","single","agentContext","/j4p/"));
+        configs.put("A", getConfig(true, 20, "executor", "fixed", "threadNr", "2"));
+        expect(ctx.getBeansOfType(SpringJolokiaConfigHolder.class)).andReturn(configs);
+        replay(ctx);
+        server.setApplicationContext(ctx);
+        server.afterPropertiesSet();
+        JolokiaServerConfig cfg = server.getServerConfig();
+        assertEquals(cfg.getExecutor(),"fixed");
+        assertEquals(cfg.getThreadNr(),2);
+        assertEquals(cfg.getContextPath(),"/j4p/");
+        checkServerAndStop(server);
+    }
+
+    private SpringJolokiaConfigHolder getConfig(boolean autoStart, int order, String ... extraArgs) {
+        SpringJolokiaConfigHolder cfg = new SpringJolokiaConfigHolder();
+        cfg.setOrder(order);
+        Map<String, String> map = new HashMap<>();
+        map.put("autoStart","" + autoStart);
+        map.put("port", "0");
+        map.put("host","127.0.0.1");
+        map.put("exposeApplicationContext", "true");
+        for (int i = 0; i < extraArgs.length; i+=2) {
+            if (extraArgs[i+1] != null) {
+                map.put(extraArgs[i],extraArgs[i+1]);
+            }
+        }
+        cfg.setConfig(map);
+        return cfg;
+    }
+
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/backend/SpringListHandlerTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/backend/SpringListHandlerTest.java
@@ -1,0 +1,32 @@
+package org.jolokia.support.spring.backend;
+
+/*
+ *
+ * Copyright 2015 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.testng.annotations.Test;
+
+/**
+ * @author roland
+ * @since 14/01/16
+ */
+public class SpringListHandlerTest {
+
+    @Test
+    public void simple() {
+    }
+
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/config/SpringConfigTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/config/SpringConfigTest.java
@@ -1,0 +1,132 @@
+package org.jolokia.support.spring.config;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.xml.parsers.*;
+
+import org.jolokia.support.spring.SpringJolokiaAgent;
+import org.jolokia.support.spring.SpringJolokiaConfigHolder;
+import org.jolokia.support.spring.SpringJolokiaLogHandlerHolder;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.config.*;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ClassPathResource;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author roland
+ * @since 29.12.12
+ */
+public class SpringConfigTest {
+
+
+    private DefaultListableBeanFactory beanFactory;
+    private XmlBeanDefinitionReader reader;
+
+
+    @BeforeTest
+	public void setUp() {
+		this.beanFactory = new DefaultListableBeanFactory();
+        this.reader = new XmlBeanDefinitionReader(this.beanFactory);
+	}
+
+    @Test
+    public void nameSpaceHandler() {
+        JolokiaNamespaceHandler handler = new JolokiaNamespaceHandler();
+        handler.init();
+    }
+
+    @Test
+    public void simpleServer() {
+
+        reader.loadBeanDefinitions(new ClassPathResource("/simple-server.xml"));
+
+        BeanDefinition bd = beanFactory.getBeanDefinition("jolokiaServer");
+        assertEquals(bd.getBeanClassName(), SpringJolokiaAgent.class.getName());
+        MutablePropertyValues props = bd.getPropertyValues();
+        assertEquals(props.size(),3);
+        assertEquals(props.getPropertyValue("lookupConfig").getValue(), false);
+        assertEquals(props.getPropertyValue("lookupServices").getValue(), false);
+        BeanDefinition cBd = (BeanDefinition) props.getPropertyValue("config").getValue();
+        assertEquals(cBd.getBeanClassName(),SpringJolokiaConfigHolder.class.getName());
+        MutablePropertyValues cProps = cBd.getPropertyValues();
+        assertEquals(cProps.size(), 1);
+        verifyConfig(cProps);
+    }
+
+    @Test
+    public void simpleConfig() {
+        reader.loadBeanDefinitions(new ClassPathResource("/simple-config.xml"));
+
+        BeanDefinition bd = beanFactory.getBeanDefinition("config");
+        assertEquals(bd.getBeanClassName(),SpringJolokiaConfigHolder.class.getName());
+        MutablePropertyValues cProps = bd.getPropertyValues();
+        assertEquals(cProps.size(),2);
+        verifyConfig(cProps);
+        assertEquals(cProps.getPropertyValue("order").getValue(), 1000);
+    }
+
+    @Test
+    public void logHandlerRef() throws IOException, SAXException, ParserConfigurationException {
+        Element element = getElement("/simple-log-ref.xml");
+        LogBeanDefinitionParser parser = new LogBeanDefinitionParser();
+        BeanDefinition bd = parser.parseInternal(element,null);
+        assertEquals(bd.getBeanClassName(), SpringJolokiaLogHandlerHolder.class.getName());
+        MutablePropertyValues props = bd.getPropertyValues();
+        assertEquals(props.size(),1);
+        assertTrue(props.getPropertyValue("logHandler").getValue() instanceof BeanReference);
+        assertEquals(((BeanReference) props.getPropertyValue("logHandler").getValue()).getBeanName(), "logHandler");
+    }
+
+    @Test
+    public void logHandlerType() throws IOException, SAXException, ParserConfigurationException {
+        Element element = getElement("/simple-log-type.xml");
+        LogBeanDefinitionParser parser = new LogBeanDefinitionParser();
+        BeanDefinition bd = parser.parseInternal(element, null);
+        assertEquals(bd.getBeanClassName(), SpringJolokiaLogHandlerHolder.class.getName());
+        MutablePropertyValues props = bd.getPropertyValues();
+        assertEquals(props.size(),2);
+        assertEquals(props.getPropertyValue("type").getValue(), "commons");
+        assertEquals(props.getPropertyValue("category").getValue(),"bla");
+    }
+
+    private void verifyConfig(MutablePropertyValues pCProps) {
+        Map<?, ?> vals = (Map<?, ?>) pCProps.getPropertyValue("config").getValue();
+        assertEquals(vals.size(),3);
+        for (String k : new String[] { "host", "port", "autoStart" }) {
+            assertTrue(vals.containsKey(new TypedStringValue(k,String.class)));
+        }
+    }
+
+    private Element getElement(String pXmlPath) throws ParserConfigurationException, IOException, SAXException {
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(getClass().getResourceAsStream(pXmlPath));
+        return doc.getDocumentElement();
+    }
+
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/config/SpringLogHandlerTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/config/SpringLogHandlerTest.java
@@ -1,0 +1,8 @@
+package org.jolokia.support.spring.config;
+
+/**
+ * @author roland
+ * @since 18.10.13
+ */
+public class SpringLogHandlerTest {
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/config/SystemPropertyModeTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/config/SystemPropertyModeTest.java
@@ -1,0 +1,39 @@
+package org.jolokia.support.spring.config;
+
+/*
+ * Copyright 2009-2013 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jolokia.server.core.config.SystemPropertyMode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * @author roland
+ * @since 01.01.13
+ */
+public class SystemPropertyModeTest {
+
+    @Test
+    public void basic() {
+        Assert.assertEquals(SystemPropertyMode.fromMode("fallback"), SystemPropertyMode.FALLBACK);
+        assertEquals(SystemPropertyMode.fromMode("NeVeR"),SystemPropertyMode.NEVER);
+        assertNull(SystemPropertyMode.fromMode("Blub"));
+        assertNull(SystemPropertyMode.fromMode(null));
+    }
+}

--- a/support/spring7/src/test/java/org/jolokia/support/spring/main/JolokiaSpringBootApplicationTest.java
+++ b/support/spring7/src/test/java/org/jolokia/support/spring/main/JolokiaSpringBootApplicationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2009-2025 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jolokia.support.spring.main;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Properties;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.web.server.WebServerFactory;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class JolokiaSpringBootApplicationTest {
+
+    @Test
+    public void runSpringBootApplication() throws IOException {
+        ConfigurableApplicationContext context = SpringApplication.run(Zero.class);
+
+        assertNotNull(context.getBean(WebServerFactory.class));
+
+        Properties props = new Properties();
+        try (InputStream is = getClass().getResourceAsStream("/application.properties")) {
+            props.load(is);
+        }
+
+        // https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.server.server.port
+        int serverPort = Integer.parseInt(props.getProperty("server.port", "8080"));
+        // https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.actuator.management.server.port
+        int managementPort = Integer.parseInt(props.getProperty("management.server.port", Integer.toString(serverPort)));
+
+        String jolokiaPath = props.getProperty("management.endpoints.web.path-mapping.jolokia", "jolokia");
+
+        URL jolokiaVersion = null;
+
+        if (serverPort == managementPort) {
+            // there's one org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext
+            //  - we can NOT configure management web context base path with management.server.base-path
+            //  - we can configure main (only) web context base path with server.servlet.context-path
+            //  - we can configure actuator base path (under server.servlet.context-path) with management.endpoints.web.base-path
+            //    (defaults to "/actuator")
+            //  - Jolokia actuator will be available at http://localhost:<server.port>/<server.servlet.context-path><spring.mvc.servlet.path><management.server.base-path>
+            String contextPath = props.getProperty("server.servlet.context-path", "");
+            if ("/".equals(contextPath)) {
+                contextPath = "";
+            }
+            String servletPath = props.getProperty("spring.mvc.servlet.path", "");
+            if ("/".equals(servletPath)) {
+                servletPath = "";
+            }
+            String actuatorPath = props.getProperty("management.endpoints.web.base-path", "/actuator");
+            if ("/".equals(actuatorPath)) {
+                actuatorPath = "";
+            }
+            jolokiaVersion = new URL("http://localhost:" + serverPort + contextPath + servletPath + actuatorPath + "/" + jolokiaPath);
+        } else {
+            // there are two org.springframework.boot.web.servlet.context.ServletWebServerApplicationContexts
+            //  - we can configure management web context base path with management.server.base-path
+            //    (defaults to "" == "/")
+            //  - we can configure actuator base path (under management.server.base-path) with management.endpoints.web.base-path
+            //    (defaults to "/actuator")
+            //  - Jolokia actuator will be available at http://localhost:<management.server.port>/<management.server.base-path><management.server.base-path>
+            String contextPath = props.getProperty("management.server.base-path", "");
+            if ("/".equals(contextPath)) {
+                contextPath = "";
+            }
+            String actuatorPath = props.getProperty("management.endpoints.web.base-path", "/actuator");
+            if ("/".equals(actuatorPath)) {
+                actuatorPath = "";
+            }
+            jolokiaVersion = new URL("http://localhost:" + managementPort + contextPath + actuatorPath + "/" + jolokiaPath);
+        }
+
+        System.out.println("Connecting to " + jolokiaVersion.toExternalForm());
+
+        URLConnection con = jolokiaVersion.openConnection();
+        if (con instanceof HttpURLConnection http) {
+            assertEquals(http.getResponseCode(), 200);
+        } else {
+            fail("Can't open HTTP connection to Jolokia actuator endpoint");
+        }
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class Zero {
+    }
+
+}

--- a/support/spring7/src/test/resources/application.properties
+++ b/support/spring7/src/test/resources/application.properties
@@ -1,0 +1,39 @@
+#
+# Copyright 2009-2025 Roland Huss
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+management.endpoint.jolokia.config.debug = true
+management.endpoints.web.exposure.include = health, jolokia, environment
+#management.endpoints.web.exposure.include = health, environment
+#management.endpoints.web.exposure.include = *
+#management.endpoints.web.exposure.exclude = jolokia
+
+server.port = 8080
+server.servlet.context-path = /main/
+# this prefix is used for DispatcherServlet mapping (defaults to "/"), but only for "main" context
+# when management.server.port != server.port, DispatcherServlet in "management" context is always mapped to "/"
+# and there's no similar property for management context's DispatcherServlet
+# trailing slash is always trimmed
+spring.mvc.servlet.path = /
+
+management.server.port = 10001
+# this base path is not used when management.server.port == server.port
+management.server.base-path = /management
+# org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties.cleanBasePath() trims
+# trailing slash
+management.endpoints.web.base-path = /endpoints
+
+# we can also map "jolokia" path (from endpoint ID) to any other path
+management.endpoints.web.path-mapping.jolokia = jolokia/jmx

--- a/support/spring7/src/test/resources/simple-config.xml
+++ b/support/spring7/src/test/resources/simple-config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2012  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<config id="config"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.jolokia.org/jolokia-spring/schema/config"
+        xsi:schemaLocation="http://www.jolokia.org/jolokia-spring/schema/config http://www.jolokia.org/jolokia-spring/schema/config/jolokia-config.xsd"
+        host="127.0.0.1"
+        order="1000"
+        port="8778"
+        autoStart="false"
+       />

--- a/support/spring7/src/test/resources/simple-log-ref.xml
+++ b/support/spring7/src/test/resources/simple-log-ref.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2012  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<log log-ref="logHandler"/>
+

--- a/support/spring7/src/test/resources/simple-log-type.xml
+++ b/support/spring7/src/test/resources/simple-log-type.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2012  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<log type="commons" category="bla"/>
+

--- a/support/spring7/src/test/resources/simple-server.xml
+++ b/support/spring7/src/test/resources/simple-server.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2012  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<agent id="jolokiaServer"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.jolokia.org/jolokia-spring/schema/config"
+       xsi:schemaLocation="http://www.jolokia.org/jolokia-spring/schema/config http://www.jolokia.org/jolokia-spring/schema/config/jolokia-config.xsd">
+  <config
+          host="127.0.0.1"
+          port="8778"
+          autoStart="false"/>
+</agent>

--- a/support/spring7/src/test/resources/spring-jolokia-context.xml
+++ b/support/spring7/src/test/resources/spring-jolokia-context.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2012  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:jolokia="http://www.jolokia.org/jolokia-spring/schema/config"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+       http://www.jolokia.org/jolokia-spring/schema/config http://www.jolokia.org/jolokia-spring/schema/config/jolokia-config.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+  <context:property-placeholder system-properties-mode="ENVIRONMENT"/>
+
+  <context:mbean-export server="jolokiaMBeanServer"/>
+
+  <jolokia:mbean-server id="jolokiaMBeanServer"/>
+
+  <jolokia:config id="bla" agentContext="/bla/" order="5"/>
+
+  <jolokia:config id="blub" agentContext="/j4p/" order="10"/>
+
+  <util:map id="configuration">
+    <entry key="jmx.jolokiaPort" value="${jolokia.port}"/>
+  </util:map>
+
+
+  <jolokia:agent id="jolokia" lookupConfig="true" lookupServices="true" exposeApplicationContext="true">
+    <jolokia:config id="blub2"
+            autoStart="true"
+            port="#{configuration['jmx.jolokiaPort']}"
+            host="127.0.0.1"
+            />
+    <jolokia:log type="slf4j"/>
+  </jolokia:agent>
+
+  <bean class="org.jolokia.support.spring.DummyRequestHandler"/>
+</beans>

--- a/support/spring7/src/test/resources/spring-jolokia-plain-beans.xml
+++ b/support/spring7/src/test/resources/spring-jolokia-plain-beans.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2012  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+  <context:property-placeholder system-properties-mode="ENVIRONMENT"/>
+
+  <util:map id="configuration">
+    <entry key="jmx.jolokiaPort" value="${jolokia.port}"/>
+  </util:map>
+
+  <bean name="server" id="jolokia" class="org.jolokia.support.spring.SpringJolokiaAgent">
+    <property name="config">
+      <bean class="org.jolokia.support.spring.SpringJolokiaConfigHolder">
+        <property name="config">
+          <util:map>
+            <entry key="autoStart" value="true"/>
+            <entry key="host" value="127.0.0.1"/>
+            <entry key="port" value="#{configuration['jmx.jolokiaPort']}"/>
+            <entry key="agentContext" value="/jolokia"/>
+          </util:map>
+        </property>
+      </bean>
+    </property>
+  </bean>
+</beans>

--- a/support/spring7/src/test/resources/spring-requesthandler-context.xml
+++ b/support/spring7/src/test/resources/spring-requesthandler-context.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2009-2016  Roland Huss
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+</beans>


### PR DESCRIPTION
Spring Boot 4 introduces some breaking changes by moving classes around. This new Spring 7 module is a copy of the original Spring module, but using Spring Boot 4 and Spring Framework 7 as dependency. The `jolokia-support-spring7` artifact is a drop-in replacement for the original `jolokia-support-spring` artifact.

This addresses issue #931