### PR TITLE
Add GraalVM Native Image support

### DIFF
--- a/agent/jvm/src/main/resources/META-INF/native-image/org.jolokia/jolokia-agent-jvm/reachability-metadata.json
+++ b/agent/jvm/src/main/resources/META-INF/native-image/org.jolokia/jolokia-agent-jvm/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "glob": "default-jolokia-agent.properties"
+    },
+    {
+      "glob": "jolokia-agent-version.properties"
+    }
+  ]
+}

--- a/core/src/main/resources/META-INF/native-image/org.jolokia/jolokia-core/reachability-metadata.json
+++ b/core/src/main/resources/META-INF/native-image/org.jolokia/jolokia-core/reachability-metadata.json
@@ -1,0 +1,47 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.converter.json.simplifier.ClassSimplifier",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.converter.json.simplifier.DomElementSimplifier",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.converter.json.simplifier.FileSimplifier",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.converter.json.simplifier.InetAddressSimplifier",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.converter.json.simplifier.ModuleSimplifier",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.converter.json.simplifier.ObjectNameSimplifier",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.converter.json.simplifier.PackageSimplifier",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.converter.json.simplifier.UrlSimplifier",
+      "allPublicConstructors": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "jolokia-core-version.properties"
+    },
+    {
+      "glob": "META-INF/jolokia/simplifiers-default"
+    },
+    {
+      "glob": "META-INF/jolokia/simplifiers"
+    }
+  ]
+}

--- a/server/core/src/main/resources/META-INF/native-image/org.jolokia/jolokia-server-core/native-image.properties
+++ b/server/core/src/main/resources/META-INF/native-image/org.jolokia/jolokia-server-core/native-image.properties
@@ -1,0 +1,3 @@
+# Jolokia's HTTP API is backed by local MBeanServer access, so native images must include JMX server support.
+# Jolokia can also proxy requests to remote JSR-160 MBean servers, which requires JMX client support.
+Args = --enable-monitoring=jmxserver,jmxclient

--- a/server/core/src/main/resources/META-INF/native-image/org.jolokia/jolokia-server-core/reachability-metadata.json
+++ b/server/core/src/main/resources/META-INF/native-image/org.jolokia/jolokia-server-core/reachability-metadata.json
@@ -1,0 +1,41 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.server.core.backend.ConfigMBean",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jolokia.server.core.backend.ConfigMBean"
+        ]
+      }
+    },
+    {
+      "type": "org.jolokia.server.core.backend.MBeanServerHandlerMBean",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.jolokia.server.core.http.AgentServlet",
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jolokia.server.core.backend.MBeanServerHandlerMBean"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "version.properties"
+    },
+    {
+      "glob": "jolokia-restrictor.xsd"
+    },
+    {
+      "glob": "META-INF/jolokia/services"
+    }
+  ]
+}

--- a/server/detector/src/main/resources/META-INF/native-image/org.jolokia/jolokia-server-detector/reachability-metadata.json
+++ b/server/detector/src/main/resources/META-INF/native-image/org.jolokia/jolokia-server-detector/reachability-metadata.json
@@ -1,0 +1,52 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.server.detector.jee.GeronimoDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.jee.GlassfishDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.jee.JBossDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.jee.JettyDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.jee.TomcatDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.jee.WeblogicDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.jee.WebsphereDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.misc.ActiveMQDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.misc.ArtemisDetector",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.server.detector.misc.LightstreamerDetector",
+      "allPublicConstructors": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/jolokia/detectors-default"
+    },
+    {
+      "glob": "META-INF/jolokia/detectors"
+    }
+  ]
+}

--- a/service/discovery/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-discovery/reachability-metadata.json
+++ b/service/discovery/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-discovery/reachability-metadata.json
@@ -1,0 +1,31 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.service.discovery.DiscoveryMulticastResponder",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.discovery.JolokiaDiscovery",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.discovery.JolokiaDiscoveryMBean",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jolokia.service.discovery.JolokiaDiscoveryMBean"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/jolokia/services-default"
+    },
+    {
+      "glob": "META-INF/jolokia/services"
+    }
+  ]
+}

--- a/service/history/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-history/reachability-metadata.json
+++ b/service/history/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-history/reachability-metadata.json
@@ -1,0 +1,27 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.service.history.HistoryMBean",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jolokia.service.history.HistoryMBean"
+        ]
+      }
+    },
+    {
+      "type": "org.jolokia.service.history.HistoryMBeanRequestInterceptor",
+      "allPublicConstructors": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/jolokia/services-default"
+    },
+    {
+      "glob": "META-INF/jolokia/services"
+    }
+  ]
+}

--- a/service/jmx/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-jmx/reachability-metadata.json
+++ b/service/jmx/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-jmx/reachability-metadata.json
@@ -1,0 +1,47 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.service.jmx.LocalRequestHandler",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.jmx.handler.ExecHandler",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.jmx.handler.ListHandler",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.jmx.handler.NotificationHandler",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.jmx.handler.ReadHandler",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.jmx.handler.SearchHandler",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.jmx.handler.WriteHandler",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.jmx.handler.list.JDKManagementCacheKeyProvider",
+      "allPublicConstructors": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/jolokia/command-handlers"
+    },
+    {
+      "glob": "META-INF/jolokia/services-default"
+    },
+    {
+      "glob": "META-INF/jolokia/services"
+    }
+  ]
+}

--- a/service/jsr160/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-jsr160/reachability-metadata.json
+++ b/service/jsr160/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-jsr160/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.service.jsr160.Jsr160RequestHandler",
+      "allPublicConstructors": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/jolokia/services-default"
+    },
+    {
+      "glob": "META-INF/jolokia/services"
+    }
+  ]
+}

--- a/service/notif/pull/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-notif-pull/reachability-metadata.json
+++ b/service/notif/pull/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-notif-pull/reachability-metadata.json
@@ -1,0 +1,27 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.service.notif.pull.PullNotificationBackend",
+      "allPublicConstructors": true
+    },
+    {
+      "type": "org.jolokia.service.notif.pull.PullNotificationStoreMBean",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jolokia.service.notif.pull.PullNotificationStoreMBean"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/jolokia/services-default"
+    },
+    {
+      "glob": "META-INF/jolokia/services"
+    }
+  ]
+}

--- a/service/notif/sse/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-notif-sse/reachability-metadata.json
+++ b/service/notif/sse/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-notif-sse/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.service.notif.sse.SseNotificationBackend",
+      "allPublicConstructors": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/jolokia/services-default"
+    },
+    {
+      "glob": "META-INF/jolokia/services"
+    }
+  ]
+}

--- a/service/serializer/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-serializer/reachability-metadata.json
+++ b/service/serializer/src/main/resources/META-INF/native-image/org.jolokia/jolokia-service-serializer/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection": [
+    {
+      "type": "org.jolokia.service.serializer.JolokiaSerializer",
+      "allPublicConstructors": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/jolokia/services-default"
+    },
+    {
+      "glob": "META-INF/jolokia/services"
+    }
+  ]
+}

--- a/support/jmx/src/main/resources/META-INF/native-image/org.jolokia/jolokia-support-jmx/reachability-metadata.json
+++ b/support/jmx/src/main/resources/META-INF/native-image/org.jolokia/jolokia-support-jmx/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection": [
+    {
+      "type": {
+        "proxy": [
+          "javax.management.MBeanServer"
+        ]
+      }
+    },
+    {
+      "type": "org.jolokia.support.jmx.JolokiaMBeanServerHolderMBean",
+      "allDeclaredMethods": true
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.jolokia.support.jmx.JolokiaMBeanServerHolderMBean"
+        ]
+      }
+    }
+  ]
+}

--- a/support/springboot/src/main/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessor.java
+++ b/support/springboot/src/main/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessor.java
@@ -1,0 +1,95 @@
+package org.jolokia.support.spring.aot;
+
+/*
+ * Copyright 2009-2026 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.ReflectionHints;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.BridgeMethodResolver;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedMetric;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Registers reflection hints for Spring JMX methods on {@link ManagedResource} beans.
+ * Jolokia invokes these methods through the JMX layer when it serves operation and
+ * attribute requests in a native image.
+ */
+public class ManagedResourceHintsAotProcessor implements BeanFactoryInitializationAotProcessor {
+
+    @Override
+    public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
+        Set<Method> managedMethods = findManagedMethods(beanFactory);
+        return managedMethods.isEmpty() ? null : new ManagedResourceHintsContribution(managedMethods);
+    }
+
+    static Set<Method> findManagedMethods(ConfigurableListableBeanFactory beanFactory) {
+        Set<Method> managedMethods = new LinkedHashSet<>();
+        for (String beanName : beanFactory.getBeanDefinitionNames()) {
+            Class<?> beanType = beanFactory.getType(beanName, false);
+            if (beanType != null) {
+                Class<?> userClass = ClassUtils.getUserClass(beanType);
+                if (AnnotationUtils.findAnnotation(userClass, ManagedResource.class) != null) {
+                    collectManagedMethods(userClass, managedMethods);
+                }
+            }
+        }
+        return managedMethods;
+    }
+
+    private static void collectManagedMethods(Class<?> userClass, Set<Method> managedMethods) {
+        ReflectionUtils.doWithMethods(userClass, method -> {
+            Method specificMethod = ClassUtils.getMostSpecificMethod(method, userClass);
+            Method bridgedMethod = BridgeMethodResolver.findBridgedMethod(specificMethod);
+            if (isManagedMethod(method) || isManagedMethod(specificMethod) || isManagedMethod(bridgedMethod)) {
+                managedMethods.add(bridgedMethod);
+            }
+        }, method -> !method.isSynthetic() && !method.isBridge());
+    }
+
+    private static boolean isManagedMethod(Method method) {
+        return AnnotationUtils.findAnnotation(method, ManagedOperation.class) != null
+                || AnnotationUtils.findAnnotation(method, ManagedAttribute.class) != null
+                || AnnotationUtils.findAnnotation(method, ManagedMetric.class) != null;
+    }
+
+    private record ManagedResourceHintsContribution(
+            Set<Method> managedMethods) implements BeanFactoryInitializationAotContribution {
+
+        @Override
+        public void applyTo(GenerationContext generationContext,
+                            @NonNull BeanFactoryInitializationCode beanFactoryInitializationCode) {
+            ReflectionHints hints = generationContext.getRuntimeHints().reflection();
+            this.managedMethods.forEach(method -> hints.registerMethod(method, ExecutableMode.INVOKE));
+        }
+
+    }
+
+}

--- a/support/springboot/src/main/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessor.java
+++ b/support/springboot/src/main/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessor.java
@@ -17,12 +17,15 @@ package org.jolokia.support.spring.aot;
  */
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.jspecify.annotations.NonNull;
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
@@ -44,24 +47,64 @@ import org.springframework.util.ReflectionUtils;
  */
 public class ManagedResourceHintsAotProcessor implements BeanFactoryInitializationAotProcessor {
 
+    /**
+     * Spring fills these classes reflectively through a {@code BeanWrapper} in
+     * {@code AnnotationJmxAttributeSource} while {@code MetadataMBeanInfoAssembler} reads the
+     * JMX annotations, so a native image needs their constructors and setters. Spring does not
+     * ship hints for them itself. {@code AbstractJmxAttribute} carries {@code description} and
+     * {@code currencyTimeLimit} for all of the concrete attributes.
+     */
+    private static final Class<?>[] JMX_METADATA_TYPES = {
+        org.springframework.jmx.export.metadata.AbstractJmxAttribute.class,
+        org.springframework.jmx.export.metadata.ManagedResource.class,
+        org.springframework.jmx.export.metadata.ManagedAttribute.class,
+        org.springframework.jmx.export.metadata.ManagedMetric.class,
+        org.springframework.jmx.export.metadata.ManagedOperation.class,
+        org.springframework.jmx.export.metadata.ManagedOperationParameter.class,
+        org.springframework.jmx.export.metadata.ManagedNotification.class
+    };
+
     @Override
     public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
-        Set<Method> managedMethods = findManagedMethods(beanFactory);
-        return managedMethods.isEmpty() ? null : new ManagedResourceHintsContribution(managedMethods);
+        Set<Method> managedMethods = new LinkedHashSet<>();
+        boolean managedResourcePresent = collectManagedResources(beanFactory, managedMethods);
+        // a @ManagedResource without any managed method still goes through the reflective
+        // metadata classes when Spring exports it, so hints are needed either way
+        return managedResourcePresent ? new ManagedResourceHintsContribution(managedMethods) : null;
     }
 
     static Set<Method> findManagedMethods(ConfigurableListableBeanFactory beanFactory) {
         Set<Method> managedMethods = new LinkedHashSet<>();
-        for (String beanName : beanFactory.getBeanDefinitionNames()) {
+        collectManagedResources(beanFactory, managedMethods);
+        return managedMethods;
+    }
+
+    private static boolean collectManagedResources(ConfigurableListableBeanFactory beanFactory,
+                                                   Set<Method> managedMethods) {
+        boolean managedResourcePresent = false;
+        for (String beanName : autodetectableBeanNames(beanFactory)) {
             Class<?> beanType = beanFactory.getType(beanName, false);
             if (beanType != null) {
                 Class<?> userClass = ClassUtils.getUserClass(beanType);
                 if (AnnotationUtils.findAnnotation(userClass, ManagedResource.class) != null) {
+                    managedResourcePresent = true;
                     collectManagedMethods(userClass, managedMethods);
                 }
             }
         }
-        return managedMethods;
+        return managedResourcePresent;
+    }
+
+    /**
+     * Mirrors {@code MBeanExporter.autodetect()}, which looks at the bean definitions and at
+     * manually registered singletons. Scanning only the definitions would miss a
+     * {@link ManagedResource} bean added through {@code registerSingleton()}.
+     */
+    private static Set<String> autodetectableBeanNames(ConfigurableListableBeanFactory beanFactory) {
+        Set<String> beanNames = new LinkedHashSet<>();
+        Collections.addAll(beanNames, beanFactory.getBeanDefinitionNames());
+        Collections.addAll(beanNames, beanFactory.getSingletonNames());
+        return beanNames;
     }
 
     private static void collectManagedMethods(Class<?> userClass, Set<Method> managedMethods) {
@@ -88,6 +131,15 @@ public class ManagedResourceHintsAotProcessor implements BeanFactoryInitializati
                             @NonNull BeanFactoryInitializationCode beanFactoryInitializationCode) {
             ReflectionHints hints = generationContext.getRuntimeHints().reflection();
             this.managedMethods.forEach(method -> hints.registerMethod(method, ExecutableMode.INVOKE));
+            for (Class<?> metadataType : JMX_METADATA_TYPES) {
+                if (Modifier.isAbstract(metadataType.getModifiers())) {
+                    // never instantiated, it only declares the setters shared by the attributes
+                    hints.registerType(metadataType, MemberCategory.INVOKE_DECLARED_METHODS);
+                } else {
+                    hints.registerType(metadataType,
+                        MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS);
+                }
+            }
         }
 
     }

--- a/support/springboot/src/main/resources/META-INF/spring/aot.factories
+++ b/support/springboot/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=\
+org.jolokia.support.spring.aot.ManagedResourceHintsAotProcessor

--- a/support/springboot/src/test/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessorTest.java
+++ b/support/springboot/src/test/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessorTest.java
@@ -1,0 +1,92 @@
+package org.jolokia.support.spring.aot;
+
+/*
+ * Copyright 2009-2026 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedMetric;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class ManagedResourceHintsAotProcessorTest {
+
+    @Test
+    public void findsManagedMethodsOnManagedResourceBeans() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+        beanFactory.registerBeanDefinition("regularBean", new RootBeanDefinition(RegularBean.class));
+
+        Set<Method> methods = ManagedResourceHintsAotProcessor.findManagedMethods(beanFactory);
+
+        assertEquals(methods.size(), 3);
+        assertTrue(containsMethod(methods, "operation"));
+        assertTrue(containsMethod(methods, "attribute"));
+        assertTrue(containsMethod(methods, "metric"));
+    }
+
+    @Test
+    public void contributesOnlyWhenManagedMethodsArePresent() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+
+        assertNotNull(new ManagedResourceHintsAotProcessor().processAheadOfTime(beanFactory));
+    }
+
+    private boolean containsMethod(Set<Method> methods, String name) {
+        return methods.stream().anyMatch(method -> method.getName().equals(name));
+    }
+
+    @ManagedResource
+    static class ManagedBean {
+
+        @ManagedOperation
+        public void operation() {
+        }
+
+        @ManagedAttribute
+        public String attribute() {
+            return "value";
+        }
+
+        @ManagedMetric
+        public int metric() {
+            return 1;
+        }
+
+        public void notManaged() {
+        }
+
+    }
+
+    static class RegularBean {
+
+        @ManagedOperation
+        public void ignoredOperation() {
+        }
+
+    }
+
+}

--- a/support/springboot/src/test/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessorTest.java
+++ b/support/springboot/src/test/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessorTest.java
@@ -17,18 +17,31 @@ package org.jolokia.support.spring.aot;
  */
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.springframework.aot.generate.GeneratedClasses;
+import org.springframework.aot.generate.GeneratedFiles;
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeHint;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedMetric;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.jmx.export.metadata.JmxAttributeSource;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class ManagedResourceHintsAotProcessorTest {
@@ -41,22 +54,182 @@ public class ManagedResourceHintsAotProcessorTest {
 
         Set<Method> methods = ManagedResourceHintsAotProcessor.findManagedMethods(beanFactory);
 
-        assertEquals(methods.size(), 3);
-        assertTrue(containsMethod(methods, "operation"));
-        assertTrue(containsMethod(methods, "attribute"));
-        assertTrue(containsMethod(methods, "metric"));
+        assertEquals(methodNames(methods), Set.of("operation", "attribute", "metric"));
     }
 
     @Test
-    public void contributesOnlyWhenManagedMethodsArePresent() {
+    public void contributesForManagedResourceBeans() {
         DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
         beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
 
         assertNotNull(new ManagedResourceHintsAotProcessor().processAheadOfTime(beanFactory));
     }
 
-    private boolean containsMethod(Set<Method> methods, String name) {
-        return methods.stream().anyMatch(method -> method.getName().equals(name));
+    @Test
+    public void skipsContributionWithoutManagedResourceBeans() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("regularBean", new RootBeanDefinition(RegularBean.class));
+
+        assertNull(new ManagedResourceHintsAotProcessor().processAheadOfTime(beanFactory));
+    }
+
+    @Test
+    public void registersInvokeHintsForManagedMethods() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+
+        RuntimeHints hints = applyContribution(beanFactory);
+
+        TypeHint typeHint = hints.reflection().getTypeHint(ManagedBean.class);
+        assertNotNull(typeHint, "missing reflection hint for the @ManagedResource bean");
+        assertEquals(typeHint.methods()
+            .map(hint -> hint.getName())
+            .collect(Collectors.toSet()), Set.of("operation", "attribute", "metric"));
+        assertTrue(typeHint.methods().allMatch(hint -> hint.getMode() == ExecutableMode.INVOKE),
+            "managed methods must be invokable, not just introspectable");
+    }
+
+    /**
+     * {@code MBeanExporter.autodetect()} reads bean definitions and manually registered
+     * singletons, so a {@code registerSingleton()} resource needs the same hints.
+     */
+    @Test
+    public void registersHintsForManuallyRegisteredSingletons() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton("managedSingleton", new ManagedBean());
+
+        RuntimeHints hints = applyContribution(beanFactory);
+
+        assertMetadataHints(hints);
+        TypeHint typeHint = hints.reflection().getTypeHint(ManagedBean.class);
+        assertNotNull(typeHint, "missing reflection hint for the singleton @ManagedResource bean");
+        assertEquals(methodNames(ManagedResourceHintsAotProcessor.findManagedMethods(beanFactory)),
+            Set.of("operation", "attribute", "metric"));
+    }
+
+    @Test
+    public void registersMetadataHintsForManagedResourceBeans() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+
+        assertMetadataHints(applyContribution(beanFactory));
+    }
+
+    /**
+     * A {@link ManagedResource} without any managed method is still exported, and Spring reads
+     * its resource metadata reflectively while doing so.
+     */
+    @Test
+    public void registersMetadataHintsForManagedResourceBeansWithoutManagedMethods() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("bareBean", new RootBeanDefinition(BareManagedBean.class));
+
+        assertMetadataHints(applyContribution(beanFactory));
+    }
+
+    /**
+     * Guards the property from the reported native image failure: {@code MBeanExporter} writes
+     * {@code currencyTimeLimit} on the metadata bean at startup, and the setter is declared on a
+     * superclass. Looking the declaring class up here keeps the test honest if Spring moves it.
+     */
+    @Test
+    public void registersHintsForTheClassDeclaringCurrencyTimeLimit() throws NoSuchMethodException {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+
+        RuntimeHints hints = applyContribution(beanFactory);
+
+        Class<?> declaringClass = org.springframework.jmx.export.metadata.ManagedResource.class
+            .getMethod("setCurrencyTimeLimit", int.class)
+            .getDeclaringClass();
+        TypeHint typeHint = hints.reflection().getTypeHint(declaringClass);
+        assertNotNull(typeHint, "missing reflection hint for " + declaringClass.getName()
+            + ", which declares setCurrencyTimeLimit");
+        assertTrue(typeHint.getMemberCategories().contains(MemberCategory.INVOKE_DECLARED_METHODS),
+            "setCurrencyTimeLimit is not invokable on " + declaringClass.getName());
+    }
+
+    /**
+     * Asserts that every JMX metadata class Spring fills reflectively is covered. The expected
+     * set is derived from {@link JmxAttributeSource} instead of being copied from the processor,
+     * so a new metadata type in Spring fails this test rather than passing silently.
+     */
+    private void assertMetadataHints(RuntimeHints hints) {
+        Set<Class<?>> expectedTypes = jmxMetadataTypes();
+        assertTrue(expectedTypes.size() >= 7, "unexpectedly few metadata types: " + expectedTypes);
+        for (Class<?> metadataType : expectedTypes) {
+            TypeHint typeHint = hints.reflection().getTypeHint(metadataType);
+            assertNotNull(typeHint, "missing reflection hint for " + metadataType.getName());
+            Set<MemberCategory> categories = typeHint.getMemberCategories();
+            assertTrue(categories.contains(MemberCategory.INVOKE_DECLARED_METHODS),
+                "setters are not invokable on " + metadataType.getName());
+            // Spring instantiates the concrete types through BeanUtils.instantiateClass
+            if (!Modifier.isAbstract(metadataType.getModifiers())) {
+                assertTrue(categories.contains(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS),
+                    "constructor is not invokable on " + metadataType.getName());
+            }
+        }
+    }
+
+    /**
+     * The {@link JmxAttributeSource} return types are exactly the classes Spring populates from
+     * the JMX annotations, plus the superclasses holding the shared properties.
+     */
+    private Set<Class<?>> jmxMetadataTypes() {
+        Set<Class<?>> types = new LinkedHashSet<>();
+        for (Method method : JmxAttributeSource.class.getMethods()) {
+            Class<?> returnType = method.getReturnType();
+            if (returnType.isArray()) {
+                returnType = returnType.getComponentType();
+            }
+            for (Class<?> type = returnType; type != null && type != Object.class; type = type.getSuperclass()) {
+                types.add(type);
+            }
+        }
+        return types;
+    }
+
+    private RuntimeHints applyContribution(DefaultListableBeanFactory beanFactory) {
+        BeanFactoryInitializationAotContribution contribution =
+            new ManagedResourceHintsAotProcessor().processAheadOfTime(beanFactory);
+        assertNotNull(contribution, "expected a contribution for the given bean factory");
+        RuntimeHintsOnlyGenerationContext generationContext = new RuntimeHintsOnlyGenerationContext();
+        contribution.applyTo(generationContext, null);
+        return generationContext.getRuntimeHints();
+    }
+
+    private Set<String> methodNames(Set<Method> methods) {
+        return methods.stream().map(Method::getName).collect(Collectors.toSet());
+    }
+
+    /**
+     * The contribution only reads {@link GenerationContext#getRuntimeHints()}, so the rest of
+     * the contract is left unimplemented on purpose to keep the test free of extra test jars.
+     */
+    private static class RuntimeHintsOnlyGenerationContext implements GenerationContext {
+
+        private final RuntimeHints runtimeHints = new RuntimeHints();
+
+        @Override
+        public GeneratedClasses getGeneratedClasses() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public GeneratedFiles getGeneratedFiles() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RuntimeHints getRuntimeHints() {
+            return this.runtimeHints;
+        }
+
+        @Override
+        public GenerationContext withName(String name) {
+            throw new UnsupportedOperationException();
+        }
+
     }
 
     @ManagedResource
@@ -75,6 +248,14 @@ public class ManagedResourceHintsAotProcessorTest {
         public int metric() {
             return 1;
         }
+
+        public void notManaged() {
+        }
+
+    }
+
+    @ManagedResource
+    static class BareManagedBean {
 
         public void notManaged() {
         }

--- a/support/springboot3/src/main/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessor.java
+++ b/support/springboot3/src/main/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessor.java
@@ -1,0 +1,95 @@
+package org.jolokia.support.spring.aot;
+
+/*
+ * Copyright 2009-2026 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.ReflectionHints;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.BridgeMethodResolver;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedMetric;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.lang.NonNull;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Registers reflection hints for Spring JMX methods on {@link ManagedResource} beans.
+ * Jolokia invokes these methods through the JMX layer when it serves operation and
+ * attribute requests in a native image.
+ */
+public class ManagedResourceHintsAotProcessor implements BeanFactoryInitializationAotProcessor {
+
+    @Override
+    public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
+        Set<Method> managedMethods = findManagedMethods(beanFactory);
+        return managedMethods.isEmpty() ? null : new ManagedResourceHintsContribution(managedMethods);
+    }
+
+    static Set<Method> findManagedMethods(ConfigurableListableBeanFactory beanFactory) {
+        Set<Method> managedMethods = new LinkedHashSet<>();
+        for (String beanName : beanFactory.getBeanDefinitionNames()) {
+            Class<?> beanType = beanFactory.getType(beanName, false);
+            if (beanType != null) {
+                Class<?> userClass = ClassUtils.getUserClass(beanType);
+                if (AnnotationUtils.findAnnotation(userClass, ManagedResource.class) != null) {
+                    collectManagedMethods(userClass, managedMethods);
+                }
+            }
+        }
+        return managedMethods;
+    }
+
+    private static void collectManagedMethods(Class<?> userClass, Set<Method> managedMethods) {
+        ReflectionUtils.doWithMethods(userClass, method -> {
+            Method specificMethod = ClassUtils.getMostSpecificMethod(method, userClass);
+            Method bridgedMethod = BridgeMethodResolver.findBridgedMethod(specificMethod);
+            if (isManagedMethod(method) || isManagedMethod(specificMethod) || isManagedMethod(bridgedMethod)) {
+                managedMethods.add(bridgedMethod);
+            }
+        }, method -> !method.isSynthetic() && !method.isBridge());
+    }
+
+    private static boolean isManagedMethod(Method method) {
+        return AnnotationUtils.findAnnotation(method, ManagedOperation.class) != null
+                || AnnotationUtils.findAnnotation(method, ManagedAttribute.class) != null
+                || AnnotationUtils.findAnnotation(method, ManagedMetric.class) != null;
+    }
+
+    private record ManagedResourceHintsContribution(
+            Set<Method> managedMethods) implements BeanFactoryInitializationAotContribution {
+
+        @Override
+        public void applyTo(GenerationContext generationContext,
+                            @NonNull BeanFactoryInitializationCode beanFactoryInitializationCode) {
+            ReflectionHints hints = generationContext.getRuntimeHints().reflection();
+            this.managedMethods.forEach(method -> hints.registerMethod(method, ExecutableMode.INVOKE));
+        }
+
+    }
+
+}

--- a/support/springboot3/src/main/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessor.java
+++ b/support/springboot3/src/main/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessor.java
@@ -17,11 +17,14 @@ package org.jolokia.support.spring.aot;
  */
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.springframework.aot.generate.GenerationContext;
 import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
 import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
@@ -44,24 +47,64 @@ import org.springframework.util.ReflectionUtils;
  */
 public class ManagedResourceHintsAotProcessor implements BeanFactoryInitializationAotProcessor {
 
+    /**
+     * Spring fills these classes reflectively through a {@code BeanWrapper} in
+     * {@code AnnotationJmxAttributeSource} while {@code MetadataMBeanInfoAssembler} reads the
+     * JMX annotations, so a native image needs their constructors and setters. Spring does not
+     * ship hints for them itself. {@code AbstractJmxAttribute} carries {@code description} and
+     * {@code currencyTimeLimit} for all of the concrete attributes.
+     */
+    private static final Class<?>[] JMX_METADATA_TYPES = {
+        org.springframework.jmx.export.metadata.AbstractJmxAttribute.class,
+        org.springframework.jmx.export.metadata.ManagedResource.class,
+        org.springframework.jmx.export.metadata.ManagedAttribute.class,
+        org.springframework.jmx.export.metadata.ManagedMetric.class,
+        org.springframework.jmx.export.metadata.ManagedOperation.class,
+        org.springframework.jmx.export.metadata.ManagedOperationParameter.class,
+        org.springframework.jmx.export.metadata.ManagedNotification.class
+    };
+
     @Override
     public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
-        Set<Method> managedMethods = findManagedMethods(beanFactory);
-        return managedMethods.isEmpty() ? null : new ManagedResourceHintsContribution(managedMethods);
+        Set<Method> managedMethods = new LinkedHashSet<>();
+        boolean managedResourcePresent = collectManagedResources(beanFactory, managedMethods);
+        // a @ManagedResource without any managed method still goes through the reflective
+        // metadata classes when Spring exports it, so hints are needed either way
+        return managedResourcePresent ? new ManagedResourceHintsContribution(managedMethods) : null;
     }
 
     static Set<Method> findManagedMethods(ConfigurableListableBeanFactory beanFactory) {
         Set<Method> managedMethods = new LinkedHashSet<>();
-        for (String beanName : beanFactory.getBeanDefinitionNames()) {
+        collectManagedResources(beanFactory, managedMethods);
+        return managedMethods;
+    }
+
+    private static boolean collectManagedResources(ConfigurableListableBeanFactory beanFactory,
+                                                   Set<Method> managedMethods) {
+        boolean managedResourcePresent = false;
+        for (String beanName : autodetectableBeanNames(beanFactory)) {
             Class<?> beanType = beanFactory.getType(beanName, false);
             if (beanType != null) {
                 Class<?> userClass = ClassUtils.getUserClass(beanType);
                 if (AnnotationUtils.findAnnotation(userClass, ManagedResource.class) != null) {
+                    managedResourcePresent = true;
                     collectManagedMethods(userClass, managedMethods);
                 }
             }
         }
-        return managedMethods;
+        return managedResourcePresent;
+    }
+
+    /**
+     * Mirrors {@code MBeanExporter.autodetect()}, which looks at the bean definitions and at
+     * manually registered singletons. Scanning only the definitions would miss a
+     * {@link ManagedResource} bean added through {@code registerSingleton()}.
+     */
+    private static Set<String> autodetectableBeanNames(ConfigurableListableBeanFactory beanFactory) {
+        Set<String> beanNames = new LinkedHashSet<>();
+        Collections.addAll(beanNames, beanFactory.getBeanDefinitionNames());
+        Collections.addAll(beanNames, beanFactory.getSingletonNames());
+        return beanNames;
     }
 
     private static void collectManagedMethods(Class<?> userClass, Set<Method> managedMethods) {
@@ -88,6 +131,15 @@ public class ManagedResourceHintsAotProcessor implements BeanFactoryInitializati
                             @NonNull BeanFactoryInitializationCode beanFactoryInitializationCode) {
             ReflectionHints hints = generationContext.getRuntimeHints().reflection();
             this.managedMethods.forEach(method -> hints.registerMethod(method, ExecutableMode.INVOKE));
+            for (Class<?> metadataType : JMX_METADATA_TYPES) {
+                if (Modifier.isAbstract(metadataType.getModifiers())) {
+                    // never instantiated, it only declares the setters shared by the attributes
+                    hints.registerType(metadataType, MemberCategory.INVOKE_DECLARED_METHODS);
+                } else {
+                    hints.registerType(metadataType,
+                        MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS);
+                }
+            }
         }
 
     }

--- a/support/springboot3/src/main/resources/META-INF/spring/aot.factories
+++ b/support/springboot3/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=\
+org.jolokia.support.spring.aot.ManagedResourceHintsAotProcessor

--- a/support/springboot3/src/test/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessorTest.java
+++ b/support/springboot3/src/test/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessorTest.java
@@ -1,0 +1,92 @@
+package org.jolokia.support.spring.aot;
+
+/*
+ * Copyright 2009-2026 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedMetric;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class ManagedResourceHintsAotProcessorTest {
+
+    @Test
+    public void findsManagedMethodsOnManagedResourceBeans() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+        beanFactory.registerBeanDefinition("regularBean", new RootBeanDefinition(RegularBean.class));
+
+        Set<Method> methods = ManagedResourceHintsAotProcessor.findManagedMethods(beanFactory);
+
+        assertEquals(methods.size(), 3);
+        assertTrue(containsMethod(methods, "operation"));
+        assertTrue(containsMethod(methods, "attribute"));
+        assertTrue(containsMethod(methods, "metric"));
+    }
+
+    @Test
+    public void contributesOnlyWhenManagedMethodsArePresent() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+
+        assertNotNull(new ManagedResourceHintsAotProcessor().processAheadOfTime(beanFactory));
+    }
+
+    private boolean containsMethod(Set<Method> methods, String name) {
+        return methods.stream().anyMatch(method -> method.getName().equals(name));
+    }
+
+    @ManagedResource
+    static class ManagedBean {
+
+        @ManagedOperation
+        public void operation() {
+        }
+
+        @ManagedAttribute
+        public String attribute() {
+            return "value";
+        }
+
+        @ManagedMetric
+        public int metric() {
+            return 1;
+        }
+
+        public void notManaged() {
+        }
+
+    }
+
+    static class RegularBean {
+
+        @ManagedOperation
+        public void ignoredOperation() {
+        }
+
+    }
+
+}

--- a/support/springboot3/src/test/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessorTest.java
+++ b/support/springboot3/src/test/java/org/jolokia/support/spring/aot/ManagedResourceHintsAotProcessorTest.java
@@ -17,18 +17,31 @@ package org.jolokia.support.spring.aot;
  */
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.springframework.aot.generate.GeneratedClasses;
+import org.springframework.aot.generate.GeneratedFiles;
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeHint;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedMetric;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.jmx.export.metadata.JmxAttributeSource;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class ManagedResourceHintsAotProcessorTest {
@@ -41,22 +54,182 @@ public class ManagedResourceHintsAotProcessorTest {
 
         Set<Method> methods = ManagedResourceHintsAotProcessor.findManagedMethods(beanFactory);
 
-        assertEquals(methods.size(), 3);
-        assertTrue(containsMethod(methods, "operation"));
-        assertTrue(containsMethod(methods, "attribute"));
-        assertTrue(containsMethod(methods, "metric"));
+        assertEquals(methodNames(methods), Set.of("operation", "attribute", "metric"));
     }
 
     @Test
-    public void contributesOnlyWhenManagedMethodsArePresent() {
+    public void contributesForManagedResourceBeans() {
         DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
         beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
 
         assertNotNull(new ManagedResourceHintsAotProcessor().processAheadOfTime(beanFactory));
     }
 
-    private boolean containsMethod(Set<Method> methods, String name) {
-        return methods.stream().anyMatch(method -> method.getName().equals(name));
+    @Test
+    public void skipsContributionWithoutManagedResourceBeans() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("regularBean", new RootBeanDefinition(RegularBean.class));
+
+        assertNull(new ManagedResourceHintsAotProcessor().processAheadOfTime(beanFactory));
+    }
+
+    @Test
+    public void registersInvokeHintsForManagedMethods() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+
+        RuntimeHints hints = applyContribution(beanFactory);
+
+        TypeHint typeHint = hints.reflection().getTypeHint(ManagedBean.class);
+        assertNotNull(typeHint, "missing reflection hint for the @ManagedResource bean");
+        assertEquals(typeHint.methods()
+            .map(hint -> hint.getName())
+            .collect(Collectors.toSet()), Set.of("operation", "attribute", "metric"));
+        assertTrue(typeHint.methods().allMatch(hint -> hint.getMode() == ExecutableMode.INVOKE),
+            "managed methods must be invokable, not just introspectable");
+    }
+
+    /**
+     * {@code MBeanExporter.autodetect()} reads bean definitions and manually registered
+     * singletons, so a {@code registerSingleton()} resource needs the same hints.
+     */
+    @Test
+    public void registersHintsForManuallyRegisteredSingletons() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton("managedSingleton", new ManagedBean());
+
+        RuntimeHints hints = applyContribution(beanFactory);
+
+        assertMetadataHints(hints);
+        TypeHint typeHint = hints.reflection().getTypeHint(ManagedBean.class);
+        assertNotNull(typeHint, "missing reflection hint for the singleton @ManagedResource bean");
+        assertEquals(methodNames(ManagedResourceHintsAotProcessor.findManagedMethods(beanFactory)),
+            Set.of("operation", "attribute", "metric"));
+    }
+
+    @Test
+    public void registersMetadataHintsForManagedResourceBeans() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+
+        assertMetadataHints(applyContribution(beanFactory));
+    }
+
+    /**
+     * A {@link ManagedResource} without any managed method is still exported, and Spring reads
+     * its resource metadata reflectively while doing so.
+     */
+    @Test
+    public void registersMetadataHintsForManagedResourceBeansWithoutManagedMethods() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("bareBean", new RootBeanDefinition(BareManagedBean.class));
+
+        assertMetadataHints(applyContribution(beanFactory));
+    }
+
+    /**
+     * Guards the property from the reported native image failure: {@code MBeanExporter} writes
+     * {@code currencyTimeLimit} on the metadata bean at startup, and the setter is declared on a
+     * superclass. Looking the declaring class up here keeps the test honest if Spring moves it.
+     */
+    @Test
+    public void registersHintsForTheClassDeclaringCurrencyTimeLimit() throws NoSuchMethodException {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("managedBean", new RootBeanDefinition(ManagedBean.class));
+
+        RuntimeHints hints = applyContribution(beanFactory);
+
+        Class<?> declaringClass = org.springframework.jmx.export.metadata.ManagedResource.class
+            .getMethod("setCurrencyTimeLimit", int.class)
+            .getDeclaringClass();
+        TypeHint typeHint = hints.reflection().getTypeHint(declaringClass);
+        assertNotNull(typeHint, "missing reflection hint for " + declaringClass.getName()
+            + ", which declares setCurrencyTimeLimit");
+        assertTrue(typeHint.getMemberCategories().contains(MemberCategory.INVOKE_DECLARED_METHODS),
+            "setCurrencyTimeLimit is not invokable on " + declaringClass.getName());
+    }
+
+    /**
+     * Asserts that every JMX metadata class Spring fills reflectively is covered. The expected
+     * set is derived from {@link JmxAttributeSource} instead of being copied from the processor,
+     * so a new metadata type in Spring fails this test rather than passing silently.
+     */
+    private void assertMetadataHints(RuntimeHints hints) {
+        Set<Class<?>> expectedTypes = jmxMetadataTypes();
+        assertTrue(expectedTypes.size() >= 7, "unexpectedly few metadata types: " + expectedTypes);
+        for (Class<?> metadataType : expectedTypes) {
+            TypeHint typeHint = hints.reflection().getTypeHint(metadataType);
+            assertNotNull(typeHint, "missing reflection hint for " + metadataType.getName());
+            Set<MemberCategory> categories = typeHint.getMemberCategories();
+            assertTrue(categories.contains(MemberCategory.INVOKE_DECLARED_METHODS),
+                "setters are not invokable on " + metadataType.getName());
+            // Spring instantiates the concrete types through BeanUtils.instantiateClass
+            if (!Modifier.isAbstract(metadataType.getModifiers())) {
+                assertTrue(categories.contains(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS),
+                    "constructor is not invokable on " + metadataType.getName());
+            }
+        }
+    }
+
+    /**
+     * The {@link JmxAttributeSource} return types are exactly the classes Spring populates from
+     * the JMX annotations, plus the superclasses holding the shared properties.
+     */
+    private Set<Class<?>> jmxMetadataTypes() {
+        Set<Class<?>> types = new LinkedHashSet<>();
+        for (Method method : JmxAttributeSource.class.getMethods()) {
+            Class<?> returnType = method.getReturnType();
+            if (returnType.isArray()) {
+                returnType = returnType.getComponentType();
+            }
+            for (Class<?> type = returnType; type != null && type != Object.class; type = type.getSuperclass()) {
+                types.add(type);
+            }
+        }
+        return types;
+    }
+
+    private RuntimeHints applyContribution(DefaultListableBeanFactory beanFactory) {
+        BeanFactoryInitializationAotContribution contribution =
+            new ManagedResourceHintsAotProcessor().processAheadOfTime(beanFactory);
+        assertNotNull(contribution, "expected a contribution for the given bean factory");
+        RuntimeHintsOnlyGenerationContext generationContext = new RuntimeHintsOnlyGenerationContext();
+        contribution.applyTo(generationContext, null);
+        return generationContext.getRuntimeHints();
+    }
+
+    private Set<String> methodNames(Set<Method> methods) {
+        return methods.stream().map(Method::getName).collect(Collectors.toSet());
+    }
+
+    /**
+     * The contribution only reads {@link GenerationContext#getRuntimeHints()}, so the rest of
+     * the contract is left unimplemented on purpose to keep the test free of extra test jars.
+     */
+    private static class RuntimeHintsOnlyGenerationContext implements GenerationContext {
+
+        private final RuntimeHints runtimeHints = new RuntimeHints();
+
+        @Override
+        public GeneratedClasses getGeneratedClasses() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public GeneratedFiles getGeneratedFiles() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RuntimeHints getRuntimeHints() {
+            return this.runtimeHints;
+        }
+
+        @Override
+        public GenerationContext withName(String name) {
+            throw new UnsupportedOperationException();
+        }
+
     }
 
     @ManagedResource
@@ -75,6 +248,14 @@ public class ManagedResourceHintsAotProcessorTest {
         public int metric() {
             return 1;
         }
+
+        public void notManaged() {
+        }
+
+    }
+
+    @ManagedResource
+    static class BareManagedBean {
 
         public void notManaged() {
         }


### PR DESCRIPTION
Add reachability metadata for Jolokia modules that load resources, services, command handlers, simplifiers, detectors, MBeans, and JMX proxies reflectively when running as a native image. Register Spring AOT hints for methods exposed through @ManagedResource beans in the Spring Boot support modules. Jolokia invokes these methods through the JMX layer, so application-specific managed operations and attributes must be registered during Spring AOT processing. Enable native JMX monitoring for the server core module because Jolokia exposes local MBeans and can proxy remote JSR-160 MBean servers.

This addresses issue https://github.com/jolokia/jolokia/issues/550