### PR TITLE
Json escaping and serializing improvements

### DIFF
--- a/json/src/main/java/org/jolokia/json/JSONWriter.java
+++ b/json/src/main/java/org/jolokia/json/JSONWriter.java
@@ -36,7 +36,7 @@ public class JSONWriter {
         writer.write('{');
         int pos = map.size() - 1;
         for (Map.Entry<String, Object> el : map.entrySet()) {
-            escape(writer, el.getKey().toCharArray());
+            escape(writer, el.getKey());
             writer.write(':');
             serialize(el.getValue(), writer);
             if (pos-- > 0) {
@@ -93,31 +93,32 @@ public class JSONWriter {
     public static void serialize(Object value, Writer writer) throws IOException {
         if (value == null) {
             writer.write("null");
-        } else if (value instanceof Boolean) {
-            writer.write((boolean) value ? "true" : "false");
-        } else if (value instanceof Float) {
-            if (Float.isFinite((float) value)) {
-                writer.write(value.toString());
+        } else if (value instanceof Boolean b) {
+            writer.write(b ? "true" : "false");
+        } else if (value instanceof Number num) {
+            if (num instanceof Double d) {
+                if (Double.isFinite(d)) {
+                    writer.write(d.toString());
+                } else {
+                    writer.write("null");
+                }
+            } else if (num instanceof Float f) {
+                if (Float.isFinite(f)) {
+                    writer.write(f.toString());
+                } else {
+                    writer.write("null");
+                }
             } else {
-                writer.write("null");
+                writer.write(num.toString());
             }
-        } else if (value instanceof Double) {
-            if (Double.isFinite((double) value)) {
-                writer.write(value.toString());
-            } else {
-                writer.write("null");
-            }
-        } else if (value instanceof Number) {
-            // includes BigDecimals and BigIntegers
-            writer.write(value.toString());
-        } else if (value instanceof Character) {
-            escape(writer, new char[] { (char) value });
-        } else if (value instanceof String) {
-            escape(writer, ((String) value).toCharArray());
+        } else if (value instanceof Character c) {
+            escape(writer, c);
+        } else if (value instanceof String s) {
+            escape(writer, s);
         } else if (value instanceof Collection<?> collection) {
             serialize(collection, writer);
-        } else if (value instanceof JSONObject) {
-            serialize((JSONObject) value, writer);
+        } else if (value instanceof JSONObject j) {
+            serialize(j, writer);
         } else if (value instanceof Map<?, ?> map) {
             // not sure about the key types, so be extra careful
             serializeAnyMap(map, writer);
@@ -135,14 +136,15 @@ public class JSONWriter {
     }
 
     /**
-     * When writing string values we have to escape characters. This method writes escaped char array into
-     * the target {@link Writer} but optimizing the process by not writing it one char at a time. Also
-     * the char array is surrounded by quotes.
+     * When writing string values we have to escape characters. This method uses a sliding-window
+     * approach to track contiguous blocks of unescaped characters.
+     * The output is enclosed in double quotes.
      * @param characters
      * @param writer
      * @throws IOException
      */
-    private static void escape(Writer writer, char[] characters) throws IOException {
+
+    private static void escape(Writer writer, String str) throws IOException {
         // https://datatracker.ietf.org/doc/html/rfc8259#section-7
         //     All Unicode characters may be placed within the
         //     quotation marks, except for the characters that MUST be escaped:
@@ -163,49 +165,62 @@ public class JSONWriter {
         // single "char" which java.lang.Character.isSurrogate() is passed directly, to be decoded by parser
         // when needed
 
-        StringBuilder buffer = new StringBuilder();
+        writer.write('"');
 
-        buffer.append('"');
-        for (char c : characters) {
-            switch (c) {
-                case '"': // %x22
-                    buffer.append("\\\"");
-                    break;
-                case '\\': // %x5C
-                    buffer.append("\\\\");
-                    break;
-                // RFC 8259 says that "/" may be escaped and we unescape it when parsing `\/`. But we don't escape
-                // it during serialization
-                case '\b':
-                    buffer.append("\\b");
-                    break;
-                case '\f':
-                    buffer.append("\\f");
-                    break;
-                case '\n':
-                    buffer.append("\\n");
-                    break;
-                case '\r':
-                    buffer.append("\\r");
-                    break;
-                case '\t':
-                    buffer.append("\\t");
-                    break;
-                default:
-                    if (c <= 0x1F) {
-                        buffer.append("\\u00");
-                        buffer.append((char)(((c & 0xf0) >> 4) + '0'));
-                        buffer.append((char)((c & 0x0f) + '0'));
-                    } else {
-                        // there's no escape
-                        buffer.append(c);
-                    }
-                    break;
+        int length = str.length();
+        int runStart = 0;
+
+        for (int i = 0; i < length; i++) {
+            char c = str.charAt(i);
+            
+            if (c > 0x1F && c != '"' && c != '\\') {
+                continue;
             }
-        }
-        buffer.append('"');
 
-        writer.write(buffer.toString());
+            if (i > runStart) {
+                writer.write(str, runStart, i - runStart);
+            }
+
+            writeEscape(writer, c);
+            runStart = i + 1;
+        }
+
+        if (runStart < length) {
+            writer.write(str, runStart, length - runStart);
+        }
+
+        writer.write('"');
+    }
+
+    private static void escape(Writer writer, char c) throws IOException {
+        writer.write('"');
+        if (c > 0x1F && c != '"' && c != '\\') {
+            writer.write(c);
+        } else {
+            writeEscape(writer, c);
+        }
+        writer.write('"');
+    }
+
+    private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
+
+    private static void writeEscape(Writer writer, char c) throws IOException {
+        switch (c) {
+            case '"':  writer.write("\\\""); break; // %x22
+            case '\\': writer.write("\\\\"); break; // %x5C
+            // RFC 8259 says that "/" may be escaped and we unescape it when parsing `\/`. But we don't escape
+            // it during serialization
+            case '\b': writer.write("\\b"); break;
+            case '\f': writer.write("\\f"); break;
+            case '\n': writer.write("\\n"); break;
+            case '\r': writer.write("\\r"); break;
+            case '\t': writer.write("\\t"); break;
+            default:
+                writer.write("\\u00");
+                writer.write(HEX_CHARS[(c >>> 4) & 0X0F]);
+                writer.write(HEX_CHARS[c & 0X0F]);
+                break;
+        }
     }
 
 }


### PR DESCRIPTION
This comes after a series of optimizations on apache artemis for ArtemisMBeanServerGuard.canInvoke (basically for jolokia's list request)
After improvements on that side, jolokia's json escaping becomes one of the lowest hanging fruits for speeding up (it accounts for about 5-10% of the cpu time).


---
There's also a bug fix according to gemini:

The firstimplementation contains a mathematical bug when escaping control characters between 0x10 and 0x1F (e.g., Data Link Escape, Device Controls). Look at how it maps the hex values to characters:
```
buffer.append((char)(((c & 0xf0) >> 4) + '0')); // For 0x10-0x1F, this evaluates to '1'
buffer.append((char)((c & 0x0f) + '0'));        // Bug here
```

If c = 0x1A (ASCII 26), the second line evaluates to 0x0A + '0', which is 10 + 48 = 58. In ASCII, 58 is the colon character (:), not a hex letter.
```
Implementation 2 output: \u001a (Correct)
Implementation 1 output: \u001: (Malformed JSON)
```
---
