### PR TITLE
[FIX] Add requestTimeoutSeconds to JVM agent to prevent CLOSE_WAIT accumulation from incomplete HTTP requests blocks single-thread executor

### DIFF
--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServer.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServer.java
@@ -53,6 +53,8 @@ import org.jolokia.server.core.util.*;
  */
 public class JolokiaServer {
 
+    private static final String JDK_HTTP_REQUEST_TIMEOUT_PROPERTY = "sun.net.httpserver.maxReqTime";
+
     // Overall configuration
     private JolokiaServerConfig config;
 
@@ -416,9 +418,15 @@ public class JolokiaServer {
         InetAddress address = pConfig.getAddress();
         InetSocketAddress socketAddress = new InetSocketAddress(address,port);
 
-        HttpServer server = pConfig.useHttps() ?
-                        createHttpsServer(socketAddress, pConfig) :
-                        HttpServer.create(socketAddress, pConfig.getBacklog());
+        String previousRequestTimeout = applyRequestTimeoutProperty(pConfig);
+        HttpServer server;
+        try {
+            server = pConfig.useHttps() ?
+                            createHttpsServer(socketAddress, pConfig) :
+                            HttpServer.create(socketAddress, pConfig.getBacklog());
+        } finally {
+            restoreSystemProperty(JDK_HTTP_REQUEST_TIMEOUT_PROPERTY, previousRequestTimeout);
+        }
 
         // Thread factory which creates only daemon threads
         ThreadFactory daemonThreadFactory = new DaemonThreadFactory(pConfig.getThreadNamePrefix());
@@ -435,6 +443,24 @@ public class JolokiaServer {
         server.setExecutor(executor);
 
         return server;
+    }
+
+    private String applyRequestTimeoutProperty(JolokiaServerConfig pConfig) {
+        if (pConfig.getRequestTimeoutSeconds() <= 0) {
+            return null;
+        }
+
+        String previousValue = System.getProperty(JDK_HTTP_REQUEST_TIMEOUT_PROPERTY);
+        System.setProperty(JDK_HTTP_REQUEST_TIMEOUT_PROPERTY, String.valueOf(pConfig.getRequestTimeoutSeconds()));
+        return previousValue;
+    }
+
+    private void restoreSystemProperty(String propertyName, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(propertyName);
+        } else {
+            System.setProperty(propertyName, previousValue);
+        }
     }
 
     // =========================================================================================================

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServerConfig.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServerConfig.java
@@ -72,6 +72,7 @@ public class JolokiaServerConfig {
     private String        executor;
     private String        threadNamePrefix;
     private int           threadNr;
+    private int           requestTimeoutSeconds;
     private String        keystore;
     private String        context;
     private boolean       useSslClientAuthentication;
@@ -285,6 +286,16 @@ public class JolokiaServerConfig {
     }
 
     /**
+     * Timeout in seconds for receiving a complete HTTP request with the embedded
+     * JDK HttpServer. A value less than or equal to zero means disabled.
+     *
+     * @return request timeout in seconds or a non-positive value when disabled.
+     */
+    public int getRequestTimeoutSeconds() {
+        return requestTimeoutSeconds;
+    }
+
+    /**
      * When the protocol is 'https' then this property indicates whether SSL client certificate
      * authentication should be used or not
      *
@@ -426,6 +437,7 @@ public class JolokiaServerConfig {
         initExecutor(agentConfig);
         initThreadNamePrefix(agentConfig);
         initThreadNr(agentConfig);
+        initRequestTimeoutSeconds(agentConfig);
         initHttpsRelatedSettings(agentConfig);
         // authenticator may use custom "authClass" with a class that's not available very early,
         // so we have to delay this initialization phase. initAuthenticator() has to be called later
@@ -691,6 +703,19 @@ public class JolokiaServerConfig {
         // Thread-Nr
         String threadNrS =  pAgentConfig.get("threadNr");
         threadNr = threadNrS != null ? Integer.parseInt(threadNrS) : 5;
+    }
+
+    private void initRequestTimeoutSeconds(Map<String, String> agentConfig) {
+        String requestTimeoutSecondsValue = agentConfig.get("requestTimeoutSeconds");
+        if (requestTimeoutSecondsValue == null) {
+            requestTimeoutSeconds = -1;
+            return;
+        }
+
+        requestTimeoutSeconds = Integer.parseInt(requestTimeoutSecondsValue);
+        if (requestTimeoutSeconds <= 0) {
+            throw new IllegalArgumentException("requestTimeoutSeconds must be greater than 0");
+        }
     }
 
     private void initExecutor(Map<String, String> agentConfig) {

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java
@@ -94,6 +94,8 @@ public class HelpCommand extends AbstractBaseCommand {
 "                                    (default: jolokia-)\n" +
 "    --threadNr <nr threads>         Number of fixed threads if \"fixed\" is used as executor\n" +
 "    --backlog <backlog>             How many request to keep in the backlog (default: 10)\n" +
+"    --requestTimeoutSeconds <sec>   Timeout in seconds for receiving a complete HTTP request\n" +
+"                                    with the embedded JDK HttpServer (disabled by default)\n" +
 "    --protocol <http|https>         Protocol which must be either \"http\" or \"https\" (default: http)\n" +
 "    --keystore <keystore>           Path to keystore (https only)\n" +
 "    --keystorePassword <pwd>        Password to the keystore (https only)\n" +

--- a/agent/jvm/src/main/java/org/jolokia/jvmagent/client/util/OptionsAndArgs.java
+++ b/agent/jvm/src/main/java/org/jolokia/jvmagent/client/util/OptionsAndArgs.java
@@ -41,7 +41,7 @@ public final class OptionsAndArgs {
             // JVM Agent options:
             "host", "port", "agentContext", "user", "password",
             "quiet!", "verbose!", "version!", "executor", "threadNamePrefix", "threadNr",
-            "backlog", "hide!", "protocol", "authMode", "authClass",
+            "backlog", "requestTimeoutSeconds", "hide!", "protocol", "authMode", "authClass",
             "authUrl", "authPrincipalSpec", "authIgnoreCerts!",
             "startTimeout",
             //https options:

--- a/agent/jvm/src/main/resources/default-jolokia-agent.properties
+++ b/agent/jvm/src/main/resources/default-jolokia-agent.properties
@@ -44,6 +44,11 @@ backlog=10
 # threadNamePrefix=jolokia-
 # nrThreads=5
 
+# Timeout in seconds for receiving a complete HTTP request with the
+# embedded JDK HttpServer. Useful for closing incomplete scanner-like
+# requests before they block the default single-thread executor.
+# requestTimeoutSeconds=5
+
 # User and password for basic authentication
 # user=bragg
 # password=secret

--- a/src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc
+++ b/src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc
@@ -195,6 +195,12 @@ a|Threading model of the HTTP server:
 `fixed` execution model is chosen.
 |`5`
 
+|`requestTimeoutSeconds`
+|Timeout in seconds for receiving a complete HTTP request with the embedded JDK HttpServer.
+This is useful for closing incomplete requests before they occupy the default single-thread executor.
+When not set, the timeout is disabled.
+|
+
 |`keystore`
 |Path to the SSL keystore to use (https only)
 |


### PR DESCRIPTION
# Fix: JVM Agent — CLOSE_WAIT accumulation from incomplete HTTP requests blocks single-thread executor

## 1. What is the Issue?

The Jolokia JVM agent embeds a JDK `HttpServer` to serve Jolokia requests. By default this server uses a **single-thread executor** (`executor=single`).

When a client (e.g. a vulnerability scanner, network probe, or misconfigured poller) opens a TCP connection to the Jolokia port and sends only a **partial HTTP request** — or sends nothing at all — the JDK HttpServer keeps the connection open indefinitely waiting for the complete request headers. Because the single-thread executor is blocked reading from that socket, **all subsequent legitimate Jolokia requests are queued and never served**.

Over time these half-open connections accumulate as `CLOSE_WAIT` sockets. The remote peer has already closed its side (sent `FIN`), but the JVM process never closes its side because the dispatcher thread is stuck waiting for data that will never arrive.

**Observed symptoms:**
- Jolokia metrics fetch calls time out.
- `netstat`/`ss` shows many `CLOSE_WAIT` entries on the Jolokia port (e.g. `:7778` or `:8778`).
- Thread dump shows `HTTP-Dispatcher` thread in a blocked read state.
- Restarting the JVM process temporarily clears the sockets.
- The issue affects **all versions** of Jolokia that use the default single-thread JDK HttpServer including the latest `2.x` release.

---

## 2. How to Reproduce (Proof of Concept)

### Prerequisites

- Java 11+
- `bash`, `nc` (or `/dev/tcp`)
- Jolokia JVM agent jar (any version, including latest 2.x)

### Steps

**Step 1 — Create a trivial Java app to attach the agent to:**

```java
// SleepApp.java
public class SleepApp {
    public static void main(String[] args) throws Exception {
        Thread.sleep(Long.MAX_VALUE);
    }
}
```

```bash
javac SleepApp.java
```

**Step 2 — Start the app with the Jolokia JVM agent:**

```bash
java -javaagent:jolokia-agent-jvm-2.6.0-javaagent.jar=port=7778,host=0.0.0.0 \
     -cp . SleepApp &
APP_PID=$!
sleep 2
```

**Step 3 — Verify Jolokia responds normally:**

```bash
curl -s http://localhost:7778/jolokia/version | python3 -m json.tool
# Expected: JSON response with {"status":200,...}
```

**Step 4 — Simulate a partial / incomplete HTTP request (the attacker / scanner):**

```bash
# Open a TCP connection and send only a partial HTTP header — never complete it
exec 99<>/dev/tcp/127.0.0.1/7778
printf "GET /jolokia/version HTTP/1.1\r\nHost: 127.0.0.1\r\n" >&99
# Do NOT send the final blank line (\r\n) that terminates headers.
# Hold the file descriptor open indefinitely.
echo "Partial connection open. Dispatcher thread is now blocked."
```

**Step 5 — Confirm legitimate requests are now blocked:**

```bash
for i in $(seq 1 5); do
    response=$(curl -s --max-time 3 http://localhost:7778/jolokia/version)
    if echo "$response" | grep -q '"status":200'; then
        echo "Request $i: SUCCESS"
    else
        echo "Request $i: FAILED (timed out or no response)"
    fi
done
```

**Expected output (demonstrating the bug):**

```
Partial connection open. Dispatcher thread is now blocked.
Request 1: FAILED (timed out or no response)
Request 2: FAILED (timed out or no response)
Request 3: FAILED (timed out or no response)
Request 4: FAILED (timed out or no response)
Request 5: FAILED (timed out or no response)
```

**Step 6 — Observe CLOSE_WAIT sockets:**

Once the remote scanner/client closes its side:

```bash
ss -tnp | grep 7778
# Shows:  CLOSE-WAIT  ... the JVM process holding the socket open
```

**Step 7 — Confirm the same behavior on the latest 2.6.0 jar:**

The above steps reproduce identically with `jolokia-agent-jvm-2.6.0-javaagent.jar`. The issue is not version-specific — it is a missing feature.

---

## 3. What Was Fixed

### Root Cause

The JDK `HttpServer` accepts the system property `sun.net.httpserver.maxReqTime` to enforce a deadline for receiving a complete HTTP request. If the deadline is exceeded the server aborts the connection and frees the thread. Jolokia never read a user-supplied timeout value and never set this property, leaving the dispatcher permanently blockable.

### Fix: New `requestTimeoutSeconds` Configuration Option

A new agent configuration option `requestTimeoutSeconds` is introduced. When set, the agent applies `sun.net.httpserver.maxReqTime` scoped to the `HttpServer` creation call, then restores the previous system property value so other components in the same JVM are not affected.

---

### Changed Files

#### `agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServerConfig.java`

**Field added:**
```java
private int requestTimeoutSeconds;
```

**Getter added:**
```java
public int getRequestTimeoutSeconds() {
    return requestTimeoutSeconds;
}
```

**Init call added inside `initConfigAndValidate`:**
```java
initRequestTimeoutSeconds(agentConfig);
```

**New init method:**
```java
private void initRequestTimeoutSeconds(Map<String, String> agentConfig) {
    String requestTimeoutSecondsValue = agentConfig.get("requestTimeoutSeconds");
    if (requestTimeoutSecondsValue == null) {
        requestTimeoutSeconds = -1;
        return;
    }

    requestTimeoutSeconds = Integer.parseInt(requestTimeoutSecondsValue);
    if (requestTimeoutSeconds <= 0) {
        throw new IllegalArgumentException("requestTimeoutSeconds must be greater than 0");
    }
}
```

---

#### `agent/jvm/src/main/java/org/jolokia/jvmagent/JolokiaServer.java`

**Constant added:**
```java
private static final String JDK_HTTP_REQUEST_TIMEOUT_PROPERTY = "sun.net.httpserver.maxReqTime";
```

**`createHttpServer` method — wrapped `HttpServer.create` with scoped property set/restore:**
```java
// BEFORE:
HttpServer server = pConfig.useHttps() ?
        createHttpsServer(socketAddress, pConfig) :
        HttpServer.create(socketAddress, pConfig.getBacklog());

// AFTER:
String previousRequestTimeout = applyRequestTimeoutProperty(pConfig);
HttpServer server;
try {
    server = pConfig.useHttps() ?
                    createHttpsServer(socketAddress, pConfig) :
                    HttpServer.create(socketAddress, pConfig.getBacklog());
} finally {
    restoreSystemProperty(JDK_HTTP_REQUEST_TIMEOUT_PROPERTY, previousRequestTimeout);
}
```

**Two new helper methods:**
```java
private String applyRequestTimeoutProperty(JolokiaServerConfig pConfig) {
    if (pConfig.getRequestTimeoutSeconds() <= 0) {
        return null;
    }
    String previousValue = System.getProperty(JDK_HTTP_REQUEST_TIMEOUT_PROPERTY);
    System.setProperty(JDK_HTTP_REQUEST_TIMEOUT_PROPERTY,
                       String.valueOf(pConfig.getRequestTimeoutSeconds()));
    return previousValue;
}

private void restoreSystemProperty(String propertyName, String previousValue) {
    if (previousValue == null) {
        System.clearProperty(propertyName);
    } else {
        System.setProperty(propertyName, previousValue);
    }
}
```

---

#### `agent/jvm/src/main/java/org/jolokia/jvmagent/client/util/OptionsAndArgs.java`

`"requestTimeoutSeconds"` added to the recognised CLI options `Set`:
```java
"backlog", "requestTimeoutSeconds", "hide!", "protocol", "authMode", "authClass",
```

---

#### `agent/jvm/src/main/java/org/jolokia/jvmagent/client/command/HelpCommand.java`

Help text added after the `--backlog` entry:
```java
"    --requestTimeoutSeconds <sec>   Timeout in seconds for receiving a complete HTTP request\n" +
"                                    with the embedded JDK HttpServer (disabled by default)\n" +
```

---

#### `agent/jvm/src/main/resources/default-jolokia-agent.properties`

Documented new option (commented out by default):
```properties
# Timeout in seconds for receiving a complete HTTP request with the
# embedded JDK HttpServer. Useful for closing incomplete scanner-like
# requests before they block the default single-thread executor.
# requestTimeoutSeconds=5
```

---

#### `src/documentation/manual/modules/ROOT/pages/agents/jvm.adoc`

New row added to the `[#agent-jvm-config]` configuration table:
```asciidoc
|`requestTimeoutSeconds`
|Timeout in seconds for receiving a complete HTTP request with the embedded JDK HttpServer.
This is useful for closing incomplete requests before they occupy the default single-thread executor.
When not set, the timeout is disabled.
|
```

---

### Usage

```bash
# As javaagent argument:
java -javaagent:jolokia-agent-jvm.jar=port=8778,requestTimeoutSeconds=5 -jar myapp.jar

# As properties file entry (default-jolokia-agent.properties):
requestTimeoutSeconds=5

# Via command-line launcher:
java -jar jolokia-agent-jvm.jar --requestTimeoutSeconds 5 start <pid>
```

A value of `5` (seconds) is recommended as a starting point. Set it low enough to evict incomplete requests promptly, but high enough to not interrupt legitimate slow clients.

---

### Verification

With `requestTimeoutSeconds=5`, after a partial-request connection is held open:

- The JDK HttpServer aborts the connection after 5 seconds.
- The dispatcher thread is freed.
- Subsequent legitimate requests succeed immediately.
- No `CLOSE_WAIT` accumulation is observed.

```
Partial connection open (held for 7 seconds)...
After timeout window:
Request 1: SUCCESS
Request 2: SUCCESS
Request 3: SUCCESS
Request 4: SUCCESS
Request 5: SUCCESS
```
