### PR TITLE
Use application/json instead of text/json content-type header

### DIFF
--- a/agent/jvm/src/test/java/org/jolokia/jvmagent/security/DelegatingAuthenticatorTest.java
+++ b/agent/jvm/src/test/java/org/jolokia/jvmagent/security/DelegatingAuthenticatorTest.java
@@ -75,7 +75,7 @@ public class DelegatingAuthenticatorTest extends BaseAuthenticatorTest {
                 if (auth == null || !auth.equals("Bearer blub")) {
                     resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 } else {
-                    resp.setContentType("text/json");
+                    resp.setContentType("application/json");
                     Writer writer = resp.getWriter();
                     if (req.getPathInfo() != null && req.getPathInfo().contains("invalid")) {
                         writer.append("{\"Invalid JSON\"");

--- a/client/javascript-esm/packages/jolokia/src/jolokia.ts
+++ b/client/javascript-esm/packages/jolokia/src/jolokia.ts
@@ -581,7 +581,7 @@ function prepareRequest(request: JolokiaRequest | JolokiaRequest[], agentOptions
 
   if (method === "post") {
     fetchOptions.method = "POST"
-    Object.assign(fetchOptions.headers, { "Content-Type": "text/json" })
+    Object.assign(fetchOptions.headers, { "Content-Type": "application/json" })
   } else {
     fetchOptions.method = "GET"
     // request can't be an array
@@ -662,7 +662,7 @@ async function performRequest(args: RequestArguments):
           return undefined
         }
         const ct = response.headers.get("content-type")
-        if (dataType === "text" || !ct || !(ct.startsWith("text/json") || ct.startsWith("application/json"))) {
+        if (dataType === "text" || !ct || !(ct.startsWith("application/json"))) {
           // text response - no parsing, single call
           const textResponse = await response.text()
           void (successCb as TextResponseCallback)(textResponse)
@@ -701,7 +701,7 @@ async function performRequest(args: RequestArguments):
             throw response
           }
           const ct = response.headers.get("content-type")
-          if (dataType === "text" || !ct || !(ct.startsWith("text/json") || ct.startsWith("application/json"))) {
+          if (dataType === "text" || !ct || !(ct.startsWith("application/json"))) {
             return response.text()
           }
           return response.json()

--- a/client/javascript-esm/packages/jolokia/test/app.ts
+++ b/client/javascript-esm/packages/jolokia/test/app.ts
@@ -44,7 +44,7 @@ app.use(/\/jolokia-timeout/, (_req, res) => {
 // a Jolokia endpoint that doesn't return proper JSON
 app.use("/jolokia-bad-json", (_req, res) => {
   res.status(200)
-  res.set("Content-Type", "text/json")
+  res.set("Content-Type", "application/json")
   res.send("<!doctype html><html lang='en'></html>")
 })
 


### PR DESCRIPTION
Noticed this one while walking around ...
JSON payloads should be served with application/json mimetype.
https://www.ietf.org/rfc/rfc4627.txt